### PR TITLE
test: Add integration tests for XDM file parsing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,3 +132,6 @@ python_files = "test_*.py"
 python_classes = "Test*"
 python_functions = "test*"
 addopts = "--cov=src/eb_model --cov-report=term-missing"
+markers = [
+    "integration: marks tests as integration tests (deselect with '-m \"not integration\"')"
+]

--- a/tests/integration/data_files/simple_demo_can_rte/config/Rte.xdm
+++ b/tests/integration/data_files/simple_demo_can_rte/config/Rte.xdm
@@ -1,0 +1,2558 @@
+<?xml version='1.0'?>
+<datamodel version="7.0" 
+           xmlns="http://www.tresos.de/_projects/DataModel2/16/root.xsd" 
+           xmlns:a="http://www.tresos.de/_projects/DataModel2/16/attribute.xsd" 
+           xmlns:v="http://www.tresos.de/_projects/DataModel2/06/schema.xsd" 
+           xmlns:d="http://www.tresos.de/_projects/DataModel2/06/data.xsd">
+
+  <d:ctr type="AUTOSAR" factory="autosar" 
+         xmlns:ad="http://www.tresos.de/_projects/DataModel2/08/admindata.xsd" 
+         xmlns:ce="http://www.tresos.de/_projects/DataModel2/18/childenable.xsd" 
+         xmlns:cd="http://www.tresos.de/_projects/DataModel2/08/customdata.xsd" 
+         xmlns:f="http://www.tresos.de/_projects/DataModel2/14/formulaexpr.xsd" 
+         xmlns:icc="http://www.tresos.de/_projects/DataModel2/08/implconfigclass.xsd" 
+         xmlns:mt="http://www.tresos.de/_projects/DataModel2/11/multitest.xsd"  
+         xmlns:variant="http://www.tresos.de/_projects/DataModel2/11/variant.xsd">
+    <d:lst type="TOP-LEVEL-PACKAGES">
+      <d:ctr name="Rte" type="AR-PACKAGE">
+        <d:lst type="ELEMENTS">
+          <d:chc name="Rte" type="AR-ELEMENT" value="MODULE-CONFIGURATION">
+            <d:ctr type="MODULE-CONFIGURATION">
+              <a:a name="DEF" value="ASPath:/TS_TxDxM6I9R0/Rte"/>
+              <d:ctr name="CommonPublishedInformation" type="IDENTIFIABLE">
+                <d:var name="ArMajorVersion" type="INTEGER" value="3">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="ArMinorVersion" type="INTEGER" value="2">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="ArPatchVersion" type="INTEGER" value="0">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="SwMajorVersion" type="INTEGER" value="6">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="SwMinorVersion" type="INTEGER" value="9"/>
+                <d:var name="SwPatchVersion" type="INTEGER" value="2"/>
+                <d:var name="ModuleId" type="INTEGER" value="2">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="VendorId" type="INTEGER" value="1">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="Release" type="STRING" value="">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+              </d:ctr>
+              <d:ctr name="PublishedInformation" type="IDENTIFIABLE">
+                <d:var name="PbcfgMSupport" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+              </d:ctr>
+              <d:var name="IMPLEMENTATION_CONFIG_VARIANT" type="ENUMERATION" 
+                     value="VariantPreCompile">
+                <a:a name="IMPORTER_INFO" value="@DEF"/>
+              </d:var>
+              <d:ctr name="RteBswGeneral" type="IDENTIFIABLE">
+                <d:var name="RteSchMVersionInfoApi" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteSchMOsScheduleTableActivationMechanism" 
+                       type="ENUMERATION" value="RELATIVE">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteSchMOsScheduleTableOffset" type="FLOAT" 
+                       value="0.01">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteUseComShadowSignalApi" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+              </d:ctr>
+              <d:lst name="RteBswModuleInstance" type="MAP">
+                <d:ctr name="BSW_BswM" type="IDENTIFIABLE">
+                  <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_BswM/Implementations/BswImplementation_0">
+                    <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  </d:ref>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP">
+                    <d:ctr name="TimingEvent_MainFunction" type="IDENTIFIABLE">
+                      <a:a name="IMPORTER_INFO" value="@CALC"/>
+                      <d:var name="RteBswActivationOffset" type="FLOAT" 
+                             value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPositionInTask" type="INTEGER" 
+                             value="7">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteBswServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_BswM/BswModuleDescriptions/BswM/InternalBehavior_0/TimingEvent_MainFunction">
+                        <a:a name="IMPORTER_INFO" value="@CALC"/>
+                      </d:ref>
+                      <d:ref name="RteBswMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/SchMDiagStateTask_20ms">
+                        <a:a name="ENABLE" value="TRUE"/>
+                        <a:a name="IMPORTER_INFO" value="@CALC"/>
+                      </d:ref>
+                      <d:var name="RteBswAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="true"/>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                </d:ctr>
+                <d:ctr name="BSW_EcuM" type="IDENTIFIABLE">
+                  <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_EcuM/Implementations/BswImplementation_0">
+                    <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  </d:ref>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP">
+                    <d:ctr name="TimingEvent_MainFunction" type="IDENTIFIABLE">
+                      <a:a name="IMPORTER_INFO" value="@CALC"/>
+                      <d:var name="RteBswActivationOffset" type="FLOAT" 
+                             value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPositionInTask" type="INTEGER" 
+                             value="6">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteBswServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_EcuM/BswModuleDescriptions/EcuM/InternalBehavior_0/TimingEvent_MainFunction">
+                        <a:a name="IMPORTER_INFO" value="@CALC"/>
+                      </d:ref>
+                      <d:ref name="RteBswMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/SchMDiagStateTask_20ms">
+                        <a:a name="ENABLE" value="TRUE"/>
+                        <a:a name="IMPORTER_INFO" value="@CALC"/>
+                      </d:ref>
+                      <d:var name="RteBswAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                </d:ctr>
+                <d:ctr name="BSW_Dem" type="IDENTIFIABLE">
+                  <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_Dem/Implementations/BswImplementation_0">
+                    <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  </d:ref>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP">
+                    <d:ctr name="TimingEvent_MainFunction" type="IDENTIFIABLE">
+                      <a:a name="IMPORTER_INFO" value="@CALC"/>
+                      <d:var name="RteBswActivationOffset" type="FLOAT" 
+                             value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPositionInTask" type="INTEGER" 
+                             value="8">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteBswServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_Dem/BswModuleDescriptions/Dem/InternalBehavior_0/TimingEvent_MainFunction">
+                        <a:a name="IMPORTER_INFO" value="@CALC"/>
+                      </d:ref>
+                      <d:ref name="RteBswMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/SchMDiagStateTask_20ms">
+                        <a:a name="ENABLE" value="TRUE"/>
+                        <a:a name="IMPORTER_INFO" value="@CALC"/>
+                      </d:ref>
+                      <d:var name="RteBswAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                </d:ctr>
+                <d:ctr name="BSW_Det" type="IDENTIFIABLE">
+                  <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_Det/Implementations/BswImplementation_0">
+                    <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  </d:ref>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP"/>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                </d:ctr>
+                <d:ctr name="BSW_PbcfgM" type="IDENTIFIABLE">
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_PbcfgM/Implementations/BswImplementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP"/>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+                <d:ctr name="BSW_Atomics" type="IDENTIFIABLE">
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_Atomics/Implementations/BswImplementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP"/>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+                <d:ctr name="BSW_Base" type="IDENTIFIABLE">
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_Base/Implementations/BswImplementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP"/>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+                <d:ctr name="BSW_PduR" type="IDENTIFIABLE">
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_PduR/Implementations/BswImplementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP"/>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+                <d:ctr name="BSW_EcuC" type="IDENTIFIABLE">
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_EcuC/Implementations/BswImplementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP"/>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+                <d:ctr name="BSW_Com" type="IDENTIFIABLE">
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_Com/Implementations/Implementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP">
+                    <d:ctr name="TimingEvent_MainFunctionRx" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteBswActivationOffset" type="FLOAT" 
+                             value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPositionInTask" type="INTEGER" 
+                             value="6">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteBswServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_Com/BswModuleDescriptions/Com/BswImplementation_0/TimingEvent_MainFunctionRx"/>
+                      <d:ref name="RteBswMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/SchMComTask_5ms">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:ref>
+                      <d:var name="RteBswAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                    <d:ctr name="TimingEvent_MainFunctionTx" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteBswActivationOffset" type="FLOAT" 
+                             value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPositionInTask" type="INTEGER" 
+                             value="8">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteBswServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_Com/BswModuleDescriptions/Com/BswImplementation_0/TimingEvent_MainFunctionTx"/>
+                      <d:ref name="RteBswMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/SchMComTask_5ms">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:ref>
+                      <d:var name="RteBswAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                    <d:ctr name="TimingEvent_MainFunctionRouteSignals" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteBswActivationOffset" type="FLOAT" 
+                             value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPositionInTask" type="INTEGER" 
+                             value="7">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteBswServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_Com/BswModuleDescriptions/Com/BswImplementation_0/TimingEvent_MainFunctionRouteSignals"/>
+                      <d:ref name="RteBswMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/SchMComTask_5ms">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:ref>
+                      <d:var name="RteBswAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+                <d:ctr name="BSW_ComM" type="IDENTIFIABLE">
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_ComM/Implementations/BswImplementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP">
+                    <d:ctr name="TimingEvent_MainFunction_0" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteBswActivationOffset" type="FLOAT" 
+                             value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPositionInTask" type="INTEGER" 
+                             value="9">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteBswServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_ComM/BswModuleDescriptions/ComM/InternalBehavior_0/TimingEvent_MainFunction_0"/>
+                      <d:ref name="RteBswMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/SchMDiagStateTask_20ms">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:ref>
+                      <d:var name="RteBswAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+                <d:ctr name="BSW_Can" type="IDENTIFIABLE">
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_Can/Implementations/BswImplementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP">
+                    <d:ctr name="TimingEvent_MainFunction_Mode" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteBswActivationOffset" type="FLOAT" 
+                             value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPositionInTask" type="INTEGER" 
+                             value="5">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteBswServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_Can/BswModuleDescriptions/Can/InternalBehavior_0/TimingEvent_MainFunction_Mode"/>
+                      <d:ref name="RteBswMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/SchMComTask_5ms">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:ref>
+                      <d:var name="RteBswAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+                <d:ctr name="BSW_CanSM" type="IDENTIFIABLE">
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_CanSM/Implementations/BswImplementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP">
+                    <d:ctr name="TimingEvent_MainFunction" type="IDENTIFIABLE">
+                      <d:var name="RteBswActivationOffset" type="FLOAT" 
+                             value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPositionInTask" type="INTEGER" 
+                             value="10">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteBswServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_CanSM/BswModuleDescriptions/CanSM/InternalBehavior_0/TimingEvent_MainFunction"/>
+                      <d:ref name="RteBswMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/SchMDiagStateTask_20ms">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:ref>
+                      <d:var name="RteBswAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+                <d:ctr name="BSW_CanIf" type="IDENTIFIABLE">
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_CanIf/Implementations/BswImplementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP"/>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+              </d:lst>
+              <d:ctr name="RteGeneration" type="IDENTIFIABLE">
+                <d:var name="ASR32RteWrapper" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="GenerateTimestamp" type="BOOLEAN" value="true">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="OverrideXfBufferComputation" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:lst name="ComTaskConfiguration" type="MAP"/>
+                <d:var name="BswmdOutputDirectory" type="STRING" >
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteGeneratorOutput" type="ENUMERATION" value="FULL"/>
+                <d:var name="RteCalibrationSupport" type="ENUMERATION" 
+                       value="NONE">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="OptimizeCdsGeneration" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteCodeVendorId" type="INTEGER" value="0">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteDevErrorDetect" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="DisableInvalidationDataConsistency" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="DisablePartitionActiveChecks" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteDevErrorDetectUninit" type="BOOLEAN" 
+                       value="true">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteGenerationMode" type="ENUMERATION" 
+                       value="COMPATIBILITY_MODE">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteMeasurementSupport" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="OsSupportsSpinlockLockMethod" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RespectConfiguredTaskType" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteOptimizationMode" type="ENUMERATION" 
+                       value="MEMORY">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="SpinlockAllocationStrategy" type="ENUMERATION" 
+                       value="OnePerChannel">
+                  <a:a name="ENABLE" value="false"/>
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="OneSendSignalQueuePerCore" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="SendSignalQueueStrategy" type="ENUMERATION" 
+                       value="Global">
+                  <a:a name="IMPORTER_INFO">
+                    <a:v>@DEF</a:v>
+                    <a:v>@CALC</a:v>
+                  </a:a>
+                </d:var>
+                <d:var name="OneScheduleTablePerPartition" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteToolChainSignificantCharacters" type="INTEGER" 
+                       value="31">
+                  <a:a name="ENABLE" value="false"/>
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteValueRangeCheckEnabled" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:lst name="RteVfbTraceClientPrefix"/>
+                <d:var name="RteVfbTraceEnabled" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:lst name="RteVfbTraceFunction"/>
+                <d:var name="OsScheduleTableMaxExpiryPoints" type="INTEGER" 
+                       value="5000">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="OSEKCompatibilityMode" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="FunctionElision" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="UnconnectedRequirePorts" type="ENUMERATION" 
+                       value="Warning">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="DataConsistencyMechanism" type="ENUMERATION" 
+                       value="OsResource">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteDataModelExport" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="InterruptBlockingFunction" type="ENUMERATION" 
+                       value="SuspendResumeAllInterrupts">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="HumanReadableBufferNames" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="ComCbkNotInterruptable" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="InterECUInvalidationHandledByRte" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="DirectReadFromCom" type="BOOLEAN" value="true">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteIocInteractionReturnValue" type="ENUMERATION" 
+                       value="RTE_IOC">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:ref name="OsCounterRef" type="REFERENCE" 
+                       value="ASPath:/Os/Os/Rte_Counter"/>
+                <d:var name="OsScheduleTableActivationMechanism" 
+                       type="ENUMERATION" value="RELATIVE">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="OsScheduleTableOffset" type="FLOAT" value="0.01">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:ref name="OsUserScheduleTableRef" type="REFERENCE" >
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:ref>
+                <d:var name="InterPartitionCommunication" type="ENUMERATION" 
+                       value="Disabled">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="GenerateEmptyRteStartStopStubs" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:ctr name="BswConfiguration" type="IDENTIFIABLE">
+                  <d:ref name="BswOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="BswOsTaskPeriod" type="FLOAT" value="0.1">
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:ref name="BswOsTaskRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="BswSendSignalQueueLength" type="INTEGER" 
+                         value="1">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="BswSendSignalGroupQueueLength" type="INTEGER" 
+                         value="1">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+                <d:ref name="SingleScheduleTablePartitionRef" type="REFERENCE" >
+                  <a:a name="ENABLE" value="false"/>
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:ref>
+                <d:lst name="CooperativeTasks" type="MAP"/>
+                <d:lst name="TaskChain" type="MAP"/>
+                <d:ctr name="OsCounterAssignments" type="IDENTIFIABLE">
+                  <a:a name="ENABLE" value="false"/>
+                  <d:lst name="OsCounterAssignment" type="MAP"/>
+                </d:ctr>
+                <d:var 
+                       name="GenerateRteFreedomFromInterferenceReviewInstructions" 
+                       type="BOOLEAN" value="false">
+                  <a:a name="ENABLE" value="false"/>
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="ExecuteTransformersDespiteLocalDataUnqueued" 
+                       type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="ExecuteTransformersDespiteLocalDataQueued" 
+                       type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var 
+                       name="InitializeImplicitWriteBufferBeforeRunnableExecutes" 
+                       type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+              </d:ctr>
+              <d:lst name="RteImplicitCommunication" type="MAP"/>
+              <d:lst name="RteInitializationBehavior" type="MAP"/>
+              <d:lst name="RteInitializationRunnableBatch" type="MAP"/>
+              <d:lst name="RteOsInteraction" type="MAP"/>
+              <d:lst name="RtePostBuildVariantConfiguration" type="MAP"/>
+              <d:ctr name="RteRips" type="IDENTIFIABLE">
+                <a:a name="ENABLE" value="false"/>
+                <d:var name="RteRipsSupport" type="ENUMERATION" 
+                       value="RTE_RIPS_OFF">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:lst name="RteRipsPluginConfigurationRef"/>
+              </d:ctr>
+              <d:lst name="RteSwComponentInstance" type="MAP">
+                <d:ctr name="SWC_ModifyEcho" type="IDENTIFIABLE">
+                  <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  <d:ctr name="DataMappings" type="IDENTIFIABLE">
+                    <a:a name="ENABLE" value="TRUE"/>
+                    <d:lst name="DataSRMapping" type="MAP">
+                      <d:ctr name="EcuMapping_1" type="IDENTIFIABLE">
+                        <d:ctr name="VariableDataPrototypeInstanceRef" 
+                               type="INSTANCE">
+                          <d:ref name="TARGET" type="REFERENCE" 
+                                 value="ASPath:/DemoApplication/PortInterfaces/If_Counter/CounterValue"/>
+                          <d:lst name="CONTEXT">
+                            <d:ref type="REFERENCE" 
+                                   value="ASPath:/DemoApplication/SwComponentTypes/SWC_ModifyEcho/R_NewCounterIn"/>
+                          </d:lst>
+                        </d:ctr>
+                        <d:chc name="DataSRKindMapping" type="IDENTIFIABLE" 
+                               value="DataSRPrimitive">
+                          <a:a name="IMPORTER_INFO" value="@DEF"/>
+                          <d:ctr name="DataSRPrimitive" type="IDENTIFIABLE">
+                            <d:ref name="SignalRef" type="REFERENCE" 
+                                   value="ASPath:/Com/Com/ComConfig/SGCounterIn_256R"/>
+                          </d:ctr>
+                          <d:ctr name="DataSRComplex" type="IDENTIFIABLE">
+                            <d:ref name="SignalGroupRef" type="REFERENCE" >
+                              <a:a name="IMPORTER_INFO" value="@DEF"/>
+                            </d:ref>
+                            <d:lst name="SignalRef"/>
+                          </d:ctr>
+                        </d:chc>
+                      </d:ctr>
+                    </d:lst>
+                  </d:ctr>
+                  <d:ref name="MappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:ref name="RteSoftwareComponentInstanceRef" 
+                         type="REFERENCE" 
+                         value="ASPath:/EcuExtract/TopLevelComposition/SWC_ModifyEcho">
+                    <a:a name="ENABLE" value="TRUE"/>
+                    <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  </d:ref>
+                  <d:lst name="RteEventToTaskMapping" type="MAP">
+                    <d:ctr name="DataReceivedEvent" type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="1">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/DemoApplication/SwComponentTypes/SWC_ModifyEcho/IB_SWC_ModifyEcho/DataReceivedEvent"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/Rte_Event_Task">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteExclusiveAreaImplementation" type="MAP"/>
+                  <d:lst name="RteExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteNvRamAllocation" type="MAP"/>
+                </d:ctr>
+                <d:ctr name="SWC_CyclicCounter" type="IDENTIFIABLE">
+                  <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  <d:ctr name="DataMappings" type="IDENTIFIABLE">
+                    <a:a name="ENABLE" value="TRUE"/>
+                    <d:lst name="DataSRMapping" type="MAP">
+                      <d:ctr name="EcuMapping_2" type="IDENTIFIABLE">
+                        <d:ctr name="VariableDataPrototypeInstanceRef" 
+                               type="INSTANCE">
+                          <d:ref name="TARGET" type="REFERENCE" 
+                                 value="ASPath:/DemoApplication/PortInterfaces/If_Counter/CounterValue"/>
+                          <d:lst name="CONTEXT">
+                            <d:ref type="REFERENCE" 
+                                   value="ASPath:/DemoApplication/SwComponentTypes/SWC_CyclicCounter/P_CounterOut"/>
+                          </d:lst>
+                        </d:ctr>
+                        <d:chc name="DataSRKindMapping" type="IDENTIFIABLE" 
+                               value="DataSRPrimitive">
+                          <a:a name="IMPORTER_INFO" value="@DEF"/>
+                          <d:ctr name="DataSRPrimitive" type="IDENTIFIABLE">
+                            <d:ref name="SignalRef" type="REFERENCE" 
+                                   value="ASPath:/Com/Com/ComConfig/SGCounterOut_272T"/>
+                          </d:ctr>
+                          <d:ctr name="DataSRComplex" type="IDENTIFIABLE">
+                            <d:ref name="SignalGroupRef" type="REFERENCE" >
+                              <a:a name="IMPORTER_INFO" value="@DEF"/>
+                            </d:ref>
+                            <d:lst name="SignalRef"/>
+                          </d:ctr>
+                        </d:chc>
+                      </d:ctr>
+                    </d:lst>
+                  </d:ctr>
+                  <d:ref name="MappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:ref name="RteSoftwareComponentInstanceRef" 
+                         type="REFERENCE" 
+                         value="ASPath:/EcuExtract/TopLevelComposition/SWC_CyclicCounter">
+                    <a:a name="ENABLE" value="TRUE"/>
+                    <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  </d:ref>
+                  <d:lst name="RteEventToTaskMapping" type="MAP">
+                    <d:ctr name="SetCounterOperationInvoked" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/DemoApplication/SwComponentTypes/SWC_CyclicCounter/IB_SWC_CyclicCounter/SetCounterOperationInvoked"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                    <d:ctr name="CyclicEvent" type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="1">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/DemoApplication/SwComponentTypes/SWC_CyclicCounter/IB_SWC_CyclicCounter/CyclicEvent"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/Rte_Time_Task">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                    <d:ctr name="ModeSwitchedRunTwo" type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="2">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/DemoApplication/SwComponentTypes/SWC_CyclicCounter/IB_SWC_CyclicCounter/ModeSwitchedRunTwo"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/Rte_Event_Task">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                    <d:ctr name="ModeSwitchedPrpShutdown" type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="3">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/DemoApplication/SwComponentTypes/SWC_CyclicCounter/IB_SWC_CyclicCounter/ModeSwitchedPrpShutdown"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/Rte_Event_Task">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteExclusiveAreaImplementation" type="MAP"/>
+                  <d:lst name="RteExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteNvRamAllocation" type="MAP"/>
+                </d:ctr>
+                <d:ctr name="SWC_IoHwAbs" type="IDENTIFIABLE">
+                  <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  <d:ctr name="DataMappings" type="IDENTIFIABLE">
+                    <a:a name="ENABLE" value="false"/>
+                    <d:lst name="DataSRMapping" type="MAP"/>
+                  </d:ctr>
+                  <d:ref name="MappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:ref name="RteSoftwareComponentInstanceRef" 
+                         type="REFERENCE" 
+                         value="ASPath:/EcuExtract/TopLevelComposition/SWC_IoHwAbs">
+                    <a:a name="ENABLE" value="TRUE"/>
+                    <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  </d:ref>
+                  <d:lst name="RteEventToTaskMapping" type="MAP">
+                    <d:ctr name="SetDiscreteValueOperationInvoked" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/DemoApplication/SwComponentTypes/SWC_IoHwAbs/IB_SWC_IoHwAbs/SetDiscreteValueOperationInvoked"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteExclusiveAreaImplementation" type="MAP"/>
+                  <d:lst name="RteExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteNvRamAllocation" type="MAP"/>
+                </d:ctr>
+                <d:ctr name="ComM_Prototype" type="IDENTIFIABLE">
+                  <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  <d:ctr name="DataMappings" type="IDENTIFIABLE">
+                    <a:a name="ENABLE" value="false"/>
+                    <d:lst name="DataSRMapping" type="MAP"/>
+                  </d:ctr>
+                  <d:ref name="MappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:ref name="RteSoftwareComponentInstanceRef" 
+                         type="REFERENCE" 
+                         value="ASPath:/EcuExtract/TopLevelComposition/ComM_Prototype">
+                    <a:a name="ENABLE" value="TRUE"/>
+                    <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  </d:ref>
+                  <d:lst name="RteEventToTaskMapping" type="MAP">
+                    <d:ctr name="EV_RequestComMode_ComMUser_0" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_ComM/SwComponentTypes/ComM/SwcInternalBehavior_0/EV_RequestComMode_ComMUser_0"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                    <d:ctr name="EV_GetCurrentComMode_ComMUser_0" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_ComM/SwComponentTypes/ComM/SwcInternalBehavior_0/EV_GetCurrentComMode_ComMUser_0"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                    <d:ctr name="EV_GetMaxComMode_ComMUser_0" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_ComM/SwComponentTypes/ComM/SwcInternalBehavior_0/EV_GetMaxComMode_ComMUser_0"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                    <d:ctr name="EV_GetRequestedComMode_ComMUser_0" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_ComM/SwComponentTypes/ComM/SwcInternalBehavior_0/EV_GetRequestedComMode_ComMUser_0"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                    <d:ctr name="EV_GetCurrentPNCComMode_ComMUser_0" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_ComM/SwComponentTypes/ComM/SwcInternalBehavior_0/EV_GetCurrentPNCComMode_ComMUser_0"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteExclusiveAreaImplementation" type="MAP"/>
+                  <d:lst name="RteExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteNvRamAllocation" type="MAP"/>
+                </d:ctr>
+                <d:ctr name="BswM_Prototype" type="IDENTIFIABLE">
+                  <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  <d:ctr name="DataMappings" type="IDENTIFIABLE">
+                    <a:a name="ENABLE" value="false"/>
+                    <d:lst name="DataSRMapping" type="MAP"/>
+                  </d:ctr>
+                  <d:ref name="MappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:ref name="RteSoftwareComponentInstanceRef" 
+                         type="REFERENCE" 
+                         value="ASPath:/EcuExtract/TopLevelComposition/BswM_Prototype">
+                    <a:a name="ENABLE" value="TRUE"/>
+                    <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  </d:ref>
+                  <d:lst name="RteEventToTaskMapping" type="MAP"/>
+                  <d:lst name="RteEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteExclusiveAreaImplementation" type="MAP"/>
+                  <d:lst name="RteExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteNvRamAllocation" type="MAP"/>
+                </d:ctr>
+                <d:ctr name="DevelopmentErrorTracer_Prototype" 
+                       type="IDENTIFIABLE">
+                  <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  <d:ctr name="DataMappings" type="IDENTIFIABLE">
+                    <a:a name="ENABLE" value="false"/>
+                    <d:lst name="DataSRMapping" type="MAP"/>
+                  </d:ctr>
+                  <d:ref name="MappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:ref name="RteSoftwareComponentInstanceRef" 
+                         type="REFERENCE" 
+                         value="ASPath:/EcuExtract/TopLevelComposition/DevelopmentErrorTracer_Prototype">
+                    <a:a name="ENABLE" value="TRUE"/>
+                    <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  </d:ref>
+                  <d:lst name="RteEventToTaskMapping" type="MAP">
+                    <d:ctr name="EV_ReportError_SWC_0" type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_Det/SwComponentTypes/DevelopmentErrorTracer/InternalBehavior/EV_ReportError_SWC_0"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteExclusiveAreaImplementation" type="MAP"/>
+                  <d:lst name="RteExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteNvRamAllocation" type="MAP"/>
+                </d:ctr>
+              </d:lst>
+              <d:lst name="RteSwComponentType" type="MAP">
+                <d:ctr name="RteSwComponentType_0" type="IDENTIFIABLE">
+                  <d:ref name="RteComponentTypeRef" type="REFERENCE" 
+                         value="ASPath:/DemoApplication/SwComponentTypes/SWC_ModifyEcho"/>
+                  <d:ref name="RteImplementationRef" type="REFERENCE" 
+                         value="ASPath:/DemoApplication/SwcImplementations/Impl_SWC_ModifyEcho">
+                    <a:a name="ENABLE" value="TRUE"/>
+                  </d:ref>
+                  <d:ctr name="RteComponentTypeCalibration" type="IDENTIFIABLE">
+                    <a:a name="ENABLE" value="false"/>
+                    <d:var name="RteCalibrationSupportEnabled" type="BOOLEAN" 
+                           value="true">
+                      <a:a name="IMPORTER_INFO" value="@DEF"/>
+                    </d:var>
+                    <d:lst name="RteCalibrationSwAddrMethodRef"/>
+                  </d:ctr>
+                </d:ctr>
+                <d:ctr name="RteSwComponentType_1" type="IDENTIFIABLE">
+                  <d:ref name="RteComponentTypeRef" type="REFERENCE" 
+                         value="ASPath:/DemoApplication/SwComponentTypes/SWC_CyclicCounter"/>
+                  <d:ref name="RteImplementationRef" type="REFERENCE" 
+                         value="ASPath:/DemoApplication/SwcImplementations/Impl_SWC_CyclicCounter">
+                    <a:a name="ENABLE" value="TRUE"/>
+                  </d:ref>
+                  <d:ctr name="RteComponentTypeCalibration" type="IDENTIFIABLE">
+                    <a:a name="ENABLE" value="false"/>
+                    <d:var name="RteCalibrationSupportEnabled" type="BOOLEAN" 
+                           value="true">
+                      <a:a name="IMPORTER_INFO" value="@DEF"/>
+                    </d:var>
+                    <d:lst name="RteCalibrationSwAddrMethodRef"/>
+                  </d:ctr>
+                </d:ctr>
+                <d:ctr name="RteSwComponentType_2" type="IDENTIFIABLE">
+                  <d:ref name="RteComponentTypeRef" type="REFERENCE" 
+                         value="ASPath:/DemoApplication/SwComponentTypes/SWC_IoHwAbs"/>
+                  <d:ref name="RteImplementationRef" type="REFERENCE" 
+                         value="ASPath:/DemoApplication/SwcImplementations/Impl_SWC_IoHwAbs">
+                    <a:a name="ENABLE" value="TRUE"/>
+                  </d:ref>
+                  <d:ctr name="RteComponentTypeCalibration" type="IDENTIFIABLE">
+                    <a:a name="ENABLE" value="false"/>
+                    <d:var name="RteCalibrationSupportEnabled" type="BOOLEAN" 
+                           value="true">
+                      <a:a name="IMPORTER_INFO" value="@DEF"/>
+                    </d:var>
+                    <d:lst name="RteCalibrationSwAddrMethodRef"/>
+                  </d:ctr>
+                </d:ctr>
+                <d:ctr name="RteSwComponentType_3" type="IDENTIFIABLE">
+                  <d:ref name="RteComponentTypeRef" type="REFERENCE" 
+                         value="ASPath:/AUTOSAR_BswM/SwComponentTypes/BswM"/>
+                  <d:ref name="RteImplementationRef" type="REFERENCE" 
+                         value="ASPath:/AUTOSAR_BswM/SwcImplementations/BswMImplementation">
+                    <a:a name="ENABLE" value="TRUE"/>
+                  </d:ref>
+                  <d:ctr name="RteComponentTypeCalibration" type="IDENTIFIABLE">
+                    <a:a name="ENABLE" value="false"/>
+                    <d:var name="RteCalibrationSupportEnabled" type="BOOLEAN" 
+                           value="true">
+                      <a:a name="IMPORTER_INFO" value="@DEF"/>
+                    </d:var>
+                    <d:lst name="RteCalibrationSwAddrMethodRef"/>
+                  </d:ctr>
+                </d:ctr>
+                <d:ctr name="RteSwComponentType_4" type="IDENTIFIABLE">
+                  <d:ref name="RteComponentTypeRef" type="REFERENCE" 
+                         value="ASPath:/AUTOSAR_Det/SwComponentTypes/DevelopmentErrorTracer"/>
+                  <d:ref name="RteImplementationRef" type="REFERENCE" 
+                         value="ASPath:/AUTOSAR_Det/Implementation">
+                    <a:a name="ENABLE" value="TRUE"/>
+                  </d:ref>
+                  <d:ctr name="RteComponentTypeCalibration" type="IDENTIFIABLE">
+                    <a:a name="ENABLE" value="false"/>
+                    <d:var name="RteCalibrationSupportEnabled" type="BOOLEAN" 
+                           value="true">
+                      <a:a name="IMPORTER_INFO" value="@DEF"/>
+                    </d:var>
+                    <d:lst name="RteCalibrationSwAddrMethodRef"/>
+                  </d:ctr>
+                </d:ctr>
+                <d:ctr name="RteSwComponentType_5" type="IDENTIFIABLE">
+                  <d:ref name="RteComponentTypeRef" type="REFERENCE" 
+                         value="ASPath:/AUTOSAR_ComM/SwComponentTypes/ComM"/>
+                  <d:ref name="RteImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_ComM/SwcImplementations/SwcImplementation_0">
+                    <a:a name="ENABLE" value="TRUE"/>
+                  </d:ref>
+                  <d:ctr name="RteComponentTypeCalibration" type="IDENTIFIABLE">
+                    <a:a name="ENABLE" value="false"/>
+                    <d:var name="RteCalibrationSupportEnabled" type="BOOLEAN" 
+                           value="true">
+                      <a:a name="IMPORTER_INFO" value="@DEF"/>
+                    </d:var>
+                    <d:lst name="RteCalibrationSwAddrMethodRef"/>
+                  </d:ctr>
+                </d:ctr>
+              </d:lst>
+            </d:ctr>
+          </d:chc>
+        </d:lst>
+      </d:ctr>
+    </d:lst>
+  </d:ctr>
+
+</datamodel>

--- a/tests/integration/data_files/simple_demo_eth_rte/config/EthIf.xdm
+++ b/tests/integration/data_files/simple_demo_eth_rte/config/EthIf.xdm
@@ -1,0 +1,449 @@
+<?xml version='1.0'?>
+<datamodel version="7.0" 
+           xmlns="http://www.tresos.de/_projects/DataModel2/16/root.xsd" 
+           xmlns:a="http://www.tresos.de/_projects/DataModel2/16/attribute.xsd" 
+           xmlns:v="http://www.tresos.de/_projects/DataModel2/06/schema.xsd" 
+           xmlns:d="http://www.tresos.de/_projects/DataModel2/06/data.xsd">
+
+  <d:ctr type="AUTOSAR" factory="autosar" 
+         xmlns:ad="http://www.tresos.de/_projects/DataModel2/08/admindata.xsd" 
+         xmlns:ce="http://www.tresos.de/_projects/DataModel2/18/childenable.xsd" 
+         xmlns:cd="http://www.tresos.de/_projects/DataModel2/08/customdata.xsd" 
+         xmlns:f="http://www.tresos.de/_projects/DataModel2/14/formulaexpr.xsd" 
+         xmlns:icc="http://www.tresos.de/_projects/DataModel2/08/implconfigclass.xsd" 
+         xmlns:mt="http://www.tresos.de/_projects/DataModel2/11/multitest.xsd"  
+         xmlns:variant="http://www.tresos.de/_projects/DataModel2/11/variant.xsd">
+    <d:lst type="TOP-LEVEL-PACKAGES">
+      <d:ctr name="EthIf" type="AR-PACKAGE">
+        <d:lst type="ELEMENTS">
+          <d:chc name="EthIf" type="AR-ELEMENT" value="MODULE-CONFIGURATION">
+            <d:ctr type="MODULE-CONFIGURATION">
+              <a:a name="DEF" value="ASPath:/TS_TxDxM1I9R0/EthIf"/>
+              <a:a name="IMPORTER_INFO" value="ImportEcuConfig"/>
+              <d:ctr name="CommonPublishedInformation" type="IDENTIFIABLE">
+                <d:var name="ArMajorVersion" type="INTEGER" value="4"/>
+                <d:var name="ArMinorVersion" type="INTEGER" value="3"/>
+                <d:var name="ArPatchVersion" type="INTEGER" value="0">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="SwMajorVersion" type="INTEGER" value="1">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="SwMinorVersion" type="INTEGER" value="9">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="SwPatchVersion" type="INTEGER" value="21"/>
+                <d:var name="ModuleId" type="INTEGER" value="65">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="VendorId" type="INTEGER" value="1">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="Release" type="STRING" value="">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+              </d:ctr>
+              <d:var name="IMPLEMENTATION_CONFIG_VARIANT" type="ENUMERATION" 
+                     value="VariantPostBuild">
+                <a:a name="IMPORTER_INFO" value="@DEF"/>
+              </d:var>
+              <d:ctr name="EthIfGeneral" type="IDENTIFIABLE">
+                <a:a name="IMPORTER_INFO" value="ImportEcuConfig"/>
+                <d:var name="EthIfDevErrorDetect" type="BOOLEAN" value="true">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfEnableRxInterrupt" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfEnableSignalQualityApi" type="BOOLEAN" 
+                       value="true">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfEnableTxInterrupt" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfEnableWEthApi" type="BOOLEAN" value="false">
+                  <a:a name="ENABLE" value="false"/>
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfGetAndResetMeasurementDataApi" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfGetBaudRate" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfGetCounterState" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfGetCtrlIdxList" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfGetTransceiverWakeupModeApi" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="ENABLE" value="false"/>
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfGetVlanIdSupport" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfGlobalTimeSupport" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfMainFunctionPeriod" type="FLOAT" value="0.01">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfMainFunctionStatePeriod" type="FLOAT" >
+                  <a:a name="ENABLE" value="false"/>
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfMaxTrcvsTotal" type="INTEGER" value="1">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfPortStartupActiveTime" type="FLOAT" >
+                  <a:a name="ENABLE" value="false"/>
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:lst name="EthIfPublicCddHeaderFile"/>
+                <d:var name="EthIfRxIndicationIterations" type="INTEGER" 
+                       value="10">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfSetForwardingModeApi" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfStartAutoNegotiation" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfSwitchManagementSupport" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfSwitchOffPortTimeDelay" type="FLOAT" >
+                  <a:a name="ENABLE" value="false"/>
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfTrcvLinkStateChgMainReload" type="INTEGER" 
+                       value="1">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfVerifyConfigApi" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfVersionInfoApi" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfVersionInfoApiMacro" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfWakeUpSupport" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfEnableSecurityEventReporting" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:ctr name="EthIfSecurityEventRefs" type="IDENTIFIABLE">
+                  <d:ref name="ETHIF_SEV_DROP_UNKNOWN_ETHERTYPE" 
+                         type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:ref name="ETHIF_SEV_DROP_VLAN_DOUBLE_TAG" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:ref name="ETHIF_SEV_DROP_INV_VLAN" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                </d:ctr>
+                <d:var name="EthIfMiiApiEnable" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfSwitchingPortGroupSupport" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfAsyncEthTrcvModeSupport" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfAsyncEthCtrlModeSupport" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfPublicHandleTypeEnum" type="ENUMERATION" 
+                       value="UINT8">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfSupportEthAPI" type="ENUMERATION" 
+                       value="ASR422"/>
+                <d:var name="EthIfMaxCtrl" type="INTEGER" value="1">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfMaxPhyCtrl" type="INTEGER" value="1">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfMaxEthSwitches" type="INTEGER" value="0">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfMaxSwtPorts" type="INTEGER" value="0">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfMaxSwtPortGroups" type="INTEGER" value="0">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfRelocatablePbcfgEnable" type="BOOLEAN" 
+                       value="true">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfSetPhysAddrSupportEnable" type="BOOLEAN" 
+                       value="false"/>
+                <d:var name="EthIfTrcvSupportEnable" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfUpdatePhysAddrFilterSupportEnable" 
+                       type="BOOLEAN" value="false"/>
+                <d:var name="EthIfVirtualCtrlSupportEnable" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfVLANSupportEnable" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:ctr name="ReportToDem" type="IDENTIFIABLE">
+                  <d:var name="EthIfDemCtrlTestResultReportToDem" 
+                         type="ENUMERATION" value="DISABLE">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="EthIfDemCtrlTestResultReportToDemDetErrorId" 
+                         type="INTEGER" value="145">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+                <d:var name="EthIfGetArlTableApi" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfGetBufferLevelApi" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfSwtGetCounterValuesApi" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfGetPortMacAddrApi" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfResetConfigurationApi" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfStoreConfigurationApi" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfSetModeTimeout" type="FLOAT" >
+                  <a:a name="ENABLE" value="false"/>
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfInitControllersTransceivers" type="BOOLEAN" 
+                       value="true">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfSwtPreProcessRxFrame" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfSwtAdpatTxFrame" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfDeviceAuthenticationApiEnable" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfRetransmitApiEnable" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+              </d:ctr>
+              <d:ctr name="EthIfDefensiveProgramming" type="IDENTIFIABLE">
+                <d:var name="EthIfDefProgEnabled" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfPrecondAssertEnabled" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfPostcondAssertEnabled" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfStaticAssertEnabled" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfUnreachAssertEnabled" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="EthIfInvariantAssertEnabled" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+              </d:ctr>
+              <d:ctr name="EthIfConfigSet" type="IDENTIFIABLE">
+                <a:a name="IMPORTER_INFO" value="ImportEcuConfig"/>
+                <d:lst name="EthIfPhysController" type="MAP">
+                  <a:a name="IMPORTER_INFO" value="ImportEcuConfig"/>
+                  <d:ctr name="EcuTestNode" type="IDENTIFIABLE">
+                    <a:a name="IMPORTER_INFO" value="ImportEcuConfig"/>
+                    <d:var name="EthIfPhysControllerIdx" type="INTEGER" 
+                           value="0"/>
+                    <d:ref name="EthIfEthCtrlRef" type="REFERENCE" 
+                           value="ASPath:/Eth/Eth/EthConfigSet/EcuTestNode">
+                      <a:a name="IMPORTER_INFO" value="ImportEcuConfig"/>
+                    </d:ref>
+                    <d:ref name="EthIfWEthCtrlRef" type="REFERENCE" >
+                      <a:a name="ENABLE" value="false"/>
+                      <a:a name="IMPORTER_INFO" value="@DEF"/>
+                    </d:ref>
+                    <d:lst name="EthIfPhysCtrlRxMainFunctionPriorityProcessing" 
+                           type="MAP"/>
+                  </d:ctr>
+                </d:lst>
+                <d:lst name="EthIfFrameOwnerConfig" type="MAP">
+                  <d:ctr name="EthIfFrameOwnerConfig_IPv4" type="IDENTIFIABLE">
+                    <a:a name="IMPORTER_INFO" value="@REC"/>
+                    <d:var name="EthIfFrameType" type="INTEGER" value="2048">
+                      <a:a name="IMPORTER_INFO" value="@REC"/>
+                    </d:var>
+                    <d:var name="EthIfOwner" type="INTEGER" value="0">
+                      <a:a name="IMPORTER_INFO" value="@REC"/>
+                    </d:var>
+                  </d:ctr>
+                  <d:ctr name="EthIfFrameOwnerConfig_IPv6" type="IDENTIFIABLE">
+                    <a:a name="IMPORTER_INFO" value="@REC"/>
+                    <d:var name="EthIfFrameType" type="INTEGER" value="34525">
+                      <a:a name="IMPORTER_INFO" value="@REC"/>
+                    </d:var>
+                    <d:var name="EthIfOwner" type="INTEGER" value="1">
+                      <a:a name="IMPORTER_INFO" value="@REC"/>
+                    </d:var>
+                  </d:ctr>
+                  <d:ctr name="EthIfFrameOwnerConfig_ARP" type="IDENTIFIABLE">
+                    <a:a name="IMPORTER_INFO" value="@REC"/>
+                    <d:var name="EthIfFrameType" type="INTEGER" value="2054">
+                      <a:a name="IMPORTER_INFO" value="@REC"/>
+                    </d:var>
+                    <d:var name="EthIfOwner" type="INTEGER" value="2">
+                      <a:a name="IMPORTER_INFO" value="@REC"/>
+                    </d:var>
+                  </d:ctr>
+                </d:lst>
+                <d:lst name="EthIfController" type="MAP">
+                  <a:a name="IMPORTER_INFO" value="ImportEcuConfig"/>
+                  <d:ctr name="EcuTestNode_EthChannel" type="IDENTIFIABLE">
+                    <a:a name="IMPORTER_INFO" value="ImportEcuConfig"/>
+                    <d:var name="EthIfCtrlIdx" type="INTEGER" value="0"/>
+                    <d:var name="EthIfCtrlMtu" type="INTEGER" value="1500">
+                      <a:a name="IMPORTER_INFO" value="@DEF"/>
+                    </d:var>
+                    <d:var name="EthIfMaxTxBufsTotal" type="INTEGER" value="1">
+                      <a:a name="IMPORTER_INFO" value="@DEF"/>
+                    </d:var>
+                    <d:var name="EthIfVlanId" type="INTEGER" value="0">
+                      <a:a name="ENABLE" value="false"/>
+                      <a:a name="IMPORTER_INFO" value="@DEF"/>
+                    </d:var>
+                    <d:ref name="EthIfEthTrcvRef" type="REFERENCE" >
+                      <a:a name="ENABLE" value="false"/>
+                      <a:a name="IMPORTER_INFO" value="@DEF"/>
+                    </d:ref>
+                    <d:ref name="EthIfPhysControllerRef" type="REFERENCE" 
+                           value="ASPath:/EthIf/EthIf/EthIfConfigSet/EcuTestNode">
+                      <a:a name="IMPORTER_INFO" value="ImportEcuConfig"/>
+                    </d:ref>
+                    <d:ref name="EthIfSwitchRefOrPortGroupRef" type="REFERENCE" >
+                      <a:a name="ENABLE" value="false"/>
+                      <a:a name="IMPORTER_INFO" value="@DEF"/>
+                    </d:ref>
+                  </d:ctr>
+                </d:lst>
+                <d:lst name="EthIfRxIndicationConfig" type="MAP">
+                  <d:ctr name="EthIfRxIndicationConfig_IPv4" 
+                         type="IDENTIFIABLE">
+                    <a:a name="IMPORTER_INFO" value="@REC"/>
+                    <d:var name="EthIfRxIndicationFunction" 
+                           type="FUNCTION-NAME" value="TcpIp_RxIndication">
+                      <a:a name="IMPORTER_INFO" value="@REC"/>
+                    </d:var>
+                  </d:ctr>
+                  <d:ctr name="EthIfRxIndicationConfig_IPv6" 
+                         type="IDENTIFIABLE">
+                    <a:a name="IMPORTER_INFO" value="@REC"/>
+                    <d:var name="EthIfRxIndicationFunction" 
+                           type="FUNCTION-NAME" value="TcpIp_RxIndication">
+                      <a:a name="IMPORTER_INFO" value="@REC"/>
+                    </d:var>
+                  </d:ctr>
+                  <d:ctr name="EthIfRxIndicationConfig_ARP" type="IDENTIFIABLE">
+                    <a:a name="IMPORTER_INFO" value="@REC"/>
+                    <d:var name="EthIfRxIndicationFunction" 
+                           type="FUNCTION-NAME" value="TcpIp_RxIndication">
+                      <a:a name="IMPORTER_INFO" value="@REC"/>
+                    </d:var>
+                  </d:ctr>
+                </d:lst>
+                <d:lst name="EthIfSwitch" type="MAP"/>
+                <d:lst name="EthIfSwitchMgmtInfoIndicationConfig" type="MAP"/>
+                <d:lst name="EthIfSwitchPortGroup" type="MAP"/>
+                <d:lst name="EthIfSwitchTimeStampIndicationConfig" type="MAP"/>
+                <d:lst name="EthIfTransceiver" type="MAP"/>
+                <d:lst name="EthIfTrcvLinkStateChgConfig" type="MAP">
+                  <d:ctr name="EthIfTrcvLinkStateChgConfig_EthSM" 
+                         type="IDENTIFIABLE">
+                    <a:a name="IMPORTER_INFO" value="@REC"/>
+                    <d:var name="EthIfTrcvLinkStateChgFunction" 
+                           type="FUNCTION-NAME" value="EthSM_TrcvLinkStateChg">
+                      <a:a name="IMPORTER_INFO" value="@REC"/>
+                    </d:var>
+                  </d:ctr>
+                </d:lst>
+                <d:lst name="EthIfTxConfirmationConfig" type="MAP">
+                  <d:ctr name="EthIfTxConfirmationConfig_0" type="IDENTIFIABLE">
+                    <a:a name="IMPORTER_INFO" value="@REC"/>
+                    <d:var name="EthIfTxConfirmationFunction" 
+                           type="FUNCTION-NAME" 
+                           value="EthIf_Up_TxConfirmationDummy">
+                      <a:a name="IMPORTER_INFO" value="@REC"/>
+                    </d:var>
+                  </d:ctr>
+                </d:lst>
+                <d:lst name="EthIfEthControllerType" type="MAP"/>
+                <d:lst name="EthIfEthTrcvType" type="MAP"/>
+                <d:lst name="EthIfEthSwtType" type="MAP"/>
+              </d:ctr>
+              <d:ctr name="PublishedInformation" type="IDENTIFIABLE">
+                <d:var name="PbcfgMSupport" type="BOOLEAN" value="true">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+              </d:ctr>
+            </d:ctr>
+          </d:chc>
+        </d:lst>
+      </d:ctr>
+    </d:lst>
+  </d:ctr>
+
+</datamodel>

--- a/tests/integration/data_files/simple_demo_eth_rte/config/Rte.xdm
+++ b/tests/integration/data_files/simple_demo_eth_rte/config/Rte.xdm
@@ -1,0 +1,2813 @@
+<?xml version='1.0'?>
+<datamodel version="7.0" 
+           xmlns="http://www.tresos.de/_projects/DataModel2/16/root.xsd" 
+           xmlns:a="http://www.tresos.de/_projects/DataModel2/16/attribute.xsd" 
+           xmlns:v="http://www.tresos.de/_projects/DataModel2/06/schema.xsd" 
+           xmlns:d="http://www.tresos.de/_projects/DataModel2/06/data.xsd">
+
+  <d:ctr type="AUTOSAR" factory="autosar" 
+         xmlns:ad="http://www.tresos.de/_projects/DataModel2/08/admindata.xsd" 
+         xmlns:ce="http://www.tresos.de/_projects/DataModel2/18/childenable.xsd" 
+         xmlns:cd="http://www.tresos.de/_projects/DataModel2/08/customdata.xsd" 
+         xmlns:f="http://www.tresos.de/_projects/DataModel2/14/formulaexpr.xsd" 
+         xmlns:icc="http://www.tresos.de/_projects/DataModel2/08/implconfigclass.xsd" 
+         xmlns:mt="http://www.tresos.de/_projects/DataModel2/11/multitest.xsd"  
+         xmlns:variant="http://www.tresos.de/_projects/DataModel2/11/variant.xsd">
+    <d:lst type="TOP-LEVEL-PACKAGES">
+      <d:ctr name="Rte" type="AR-PACKAGE">
+        <d:lst type="ELEMENTS">
+          <d:chc name="Rte" type="AR-ELEMENT" value="MODULE-CONFIGURATION">
+            <d:ctr type="MODULE-CONFIGURATION">
+              <a:a name="DEF" value="ASPath:/TS_TxDxM6I9R0/Rte"/>
+              <d:ctr name="CommonPublishedInformation" type="IDENTIFIABLE">
+                <d:var name="ArMajorVersion" type="INTEGER" value="3">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="ArMinorVersion" type="INTEGER" value="2">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="ArPatchVersion" type="INTEGER" value="0">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="SwMajorVersion" type="INTEGER" value="6">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="SwMinorVersion" type="INTEGER" value="9"/>
+                <d:var name="SwPatchVersion" type="INTEGER" value="2"/>
+                <d:var name="ModuleId" type="INTEGER" value="2">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="VendorId" type="INTEGER" value="1">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="Release" type="STRING" value="">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+              </d:ctr>
+              <d:ctr name="PublishedInformation" type="IDENTIFIABLE">
+                <d:var name="PbcfgMSupport" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+              </d:ctr>
+              <d:var name="IMPLEMENTATION_CONFIG_VARIANT" type="ENUMERATION" 
+                     value="VariantPreCompile">
+                <a:a name="IMPORTER_INFO" value="@DEF"/>
+              </d:var>
+              <d:ctr name="RteBswGeneral" type="IDENTIFIABLE">
+                <d:var name="RteSchMVersionInfoApi" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteSchMOsScheduleTableActivationMechanism" 
+                       type="ENUMERATION" value="RELATIVE">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteSchMOsScheduleTableOffset" type="FLOAT" 
+                       value="0.01">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteUseComShadowSignalApi" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+              </d:ctr>
+              <d:lst name="RteBswModuleInstance" type="MAP">
+                <d:ctr name="BSW_BswM" type="IDENTIFIABLE">
+                  <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_BswM/Implementations/BswImplementation_0">
+                    <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  </d:ref>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP">
+                    <d:ctr name="TimingEvent_MainFunction" type="IDENTIFIABLE">
+                      <a:a name="IMPORTER_INFO" value="@CALC"/>
+                      <d:var name="RteBswActivationOffset" type="FLOAT" 
+                             value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPositionInTask" type="INTEGER" 
+                             value="2">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteBswServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_BswM/BswModuleDescriptions/BswM/InternalBehavior_0/TimingEvent_MainFunction">
+                        <a:a name="IMPORTER_INFO" value="@CALC"/>
+                      </d:ref>
+                      <d:ref name="RteBswMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/SchMDiagStateTask_20ms">
+                        <a:a name="ENABLE" value="TRUE"/>
+                        <a:a name="IMPORTER_INFO" value="@CALC"/>
+                      </d:ref>
+                      <d:var name="RteBswAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="true"/>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                </d:ctr>
+                <d:ctr name="BSW_EcuM" type="IDENTIFIABLE">
+                  <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_EcuM/Implementations/BswImplementation_0">
+                    <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  </d:ref>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP">
+                    <d:ctr name="TimingEvent_MainFunction" type="IDENTIFIABLE">
+                      <a:a name="IMPORTER_INFO" value="@CALC"/>
+                      <d:var name="RteBswActivationOffset" type="FLOAT" 
+                             value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPositionInTask" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteBswServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_EcuM/BswModuleDescriptions/EcuM/InternalBehavior_0/TimingEvent_MainFunction">
+                        <a:a name="IMPORTER_INFO" value="@CALC"/>
+                      </d:ref>
+                      <d:ref name="RteBswMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/SchMDiagStateTask_20ms">
+                        <a:a name="ENABLE" value="TRUE"/>
+                        <a:a name="IMPORTER_INFO" value="@CALC"/>
+                      </d:ref>
+                      <d:var name="RteBswAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                </d:ctr>
+                <d:ctr name="BSW_Dem" type="IDENTIFIABLE">
+                  <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_Dem/Implementations/BswImplementation_0">
+                    <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  </d:ref>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP">
+                    <d:ctr name="TimingEvent_MainFunction" type="IDENTIFIABLE">
+                      <a:a name="IMPORTER_INFO" value="@CALC"/>
+                      <d:var name="RteBswActivationOffset" type="FLOAT" 
+                             value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPositionInTask" type="INTEGER" 
+                             value="3">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteBswServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_Dem/BswModuleDescriptions/Dem/InternalBehavior_0/TimingEvent_MainFunction">
+                        <a:a name="IMPORTER_INFO" value="@CALC"/>
+                      </d:ref>
+                      <d:ref name="RteBswMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/SchMDiagStateTask_20ms">
+                        <a:a name="ENABLE" value="TRUE"/>
+                        <a:a name="IMPORTER_INFO" value="@CALC"/>
+                      </d:ref>
+                      <d:var name="RteBswAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                </d:ctr>
+                <d:ctr name="BSW_Det" type="IDENTIFIABLE">
+                  <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_Det/Implementations/BswImplementation_0">
+                    <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  </d:ref>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP"/>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                </d:ctr>
+                <d:ctr name="BSW_PbcfgM" type="IDENTIFIABLE">
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_PbcfgM/Implementations/BswImplementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP"/>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+                <d:ctr name="BSW_Atomics" type="IDENTIFIABLE">
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_Atomics/Implementations/BswImplementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP"/>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+                <d:ctr name="BSW_Base" type="IDENTIFIABLE">
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_Base/Implementations/BswImplementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP"/>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+                <d:ctr name="BSW_TcpIp" type="IDENTIFIABLE">
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_TcpIp/Implementations/BswImplementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP">
+                    <d:ctr name="TimingEvent_MainFunction" type="IDENTIFIABLE">
+                      <d:var name="RteBswActivationOffset" type="FLOAT" 
+                             value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPositionInTask" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteBswServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_TcpIp/BswModuleDescriptions/TcpIp/InternalBehavior_0/TimingEvent_MainFunction"/>
+                      <d:ref name="RteBswMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/SchMComTask_100ms">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:ref>
+                      <d:var name="RteBswAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+                <d:ctr name="BSW_SoAd" type="IDENTIFIABLE">
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_SoAd/Implementations/BswImplementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP">
+                    <d:ctr name="TimingEvent_MainFunction" type="IDENTIFIABLE">
+                      <d:var name="RteBswActivationOffset" type="FLOAT" 
+                             value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPositionInTask" type="INTEGER" 
+                             value="2">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteBswServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_SoAd/BswModuleDescriptions/SoAd/InternalBehavior_0/TimingEvent_MainFunction"/>
+                      <d:ref name="RteBswMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/SchMComTask_100ms">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:ref>
+                      <d:var name="RteBswAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+                <d:ctr name="BSW_PduR" type="IDENTIFIABLE">
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_PduR/Implementations/BswImplementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP"/>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+                <d:ctr name="BSW_Eth" type="IDENTIFIABLE">
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_Eth/Implementations/BswImplementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP"/>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+                <d:ctr name="BSW_EthSM" type="IDENTIFIABLE">
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_EthSM/Implementations/BswImplementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP">
+                    <d:ctr name="TimingEvent_MainFunction" type="IDENTIFIABLE">
+                      <d:var name="RteBswActivationOffset" type="FLOAT" 
+                             value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPositionInTask" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteBswServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_EthSM/BswModuleDescriptions/EthSM/InternalBehavior_0/TimingEvent_MainFunction"/>
+                      <d:ref name="RteBswMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/SchMComTask_10ms">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:ref>
+                      <d:var name="RteBswAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+                <d:ctr name="BSW_EthIf" type="IDENTIFIABLE">
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_EthIf/Implementations/BswImplementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP">
+                    <d:ctr name="TimingEvent_MainFunctionRx" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteBswActivationOffset" type="FLOAT" 
+                             value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPositionInTask" type="INTEGER" 
+                             value="2">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteBswServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_EthIf/BswModuleDescriptions/EthIf/InternalBehavior_0/TimingEvent_MainFunctionRx"/>
+                      <d:ref name="RteBswMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/SchMComTask_10ms">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:ref>
+                      <d:var name="RteBswAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                    <d:ctr name="TimingEvent_MainFunctionTx" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteBswActivationOffset" type="FLOAT" 
+                             value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPositionInTask" type="INTEGER" 
+                             value="3">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteBswServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_EthIf/BswModuleDescriptions/EthIf/InternalBehavior_0/TimingEvent_MainFunctionTx"/>
+                      <d:ref name="RteBswMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/SchMComTask_10ms">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:ref>
+                      <d:var name="RteBswAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+                <d:ctr name="BSW_EcuC" type="IDENTIFIABLE">
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_EcuC/Implementations/BswImplementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP"/>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+                <d:ctr name="BSW_Com" type="IDENTIFIABLE">
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_Com/Implementations/Implementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP">
+                    <d:ctr name="TimingEvent_MainFunctionRx" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteBswActivationOffset" type="FLOAT" 
+                             value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPositionInTask" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteBswServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_Com/BswModuleDescriptions/Com/BswImplementation_0/TimingEvent_MainFunctionRx"/>
+                      <d:ref name="RteBswMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/SchMComTask_5ms">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:ref>
+                      <d:var name="RteBswAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                    <d:ctr name="TimingEvent_MainFunctionTx" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteBswActivationOffset" type="FLOAT" 
+                             value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPositionInTask" type="INTEGER" 
+                             value="3">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteBswServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_Com/BswModuleDescriptions/Com/BswImplementation_0/TimingEvent_MainFunctionTx"/>
+                      <d:ref name="RteBswMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/SchMComTask_5ms">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:ref>
+                      <d:var name="RteBswAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                    <d:ctr name="TimingEvent_MainFunctionRouteSignals" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteBswActivationOffset" type="FLOAT" 
+                             value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPositionInTask" type="INTEGER" 
+                             value="2">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteBswServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_Com/BswModuleDescriptions/Com/BswImplementation_0/TimingEvent_MainFunctionRouteSignals"/>
+                      <d:ref name="RteBswMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/SchMComTask_5ms">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:ref>
+                      <d:var name="RteBswAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+                <d:ctr name="BSW_ComM" type="IDENTIFIABLE">
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_ComM/Implementations/BswImplementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP">
+                    <d:ctr name="TimingEvent_MainFunction_0" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteBswActivationOffset" type="FLOAT" 
+                             value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPositionInTask" type="INTEGER" 
+                             value="4">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteBswServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_ComM/BswModuleDescriptions/ComM/InternalBehavior_0/TimingEvent_MainFunction_0"/>
+                      <d:ref name="RteBswMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/SchMDiagStateTask_20ms">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:ref>
+                      <d:var name="RteBswAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+              </d:lst>
+              <d:ctr name="RteGeneration" type="IDENTIFIABLE">
+                <d:var name="ASR32RteWrapper" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="GenerateTimestamp" type="BOOLEAN" value="true">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="OverrideXfBufferComputation" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:lst name="ComTaskConfiguration" type="MAP"/>
+                <d:var name="BswmdOutputDirectory" type="STRING" >
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="OptimizeCdsGeneration" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RespectConfiguredTaskType" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="SpinlockAllocationStrategy" type="ENUMERATION" 
+                       value="OnePerChannel">
+                  <a:a name="ENABLE" value="false"/>
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="SendSignalQueueStrategy" type="ENUMERATION" 
+                       value="Global">
+                  <a:a name="IMPORTER_INFO">
+                    <a:v>@DEF</a:v>
+                    <a:v>@CALC</a:v>
+                  </a:a>
+                </d:var>
+                <d:var name="OneScheduleTablePerPartition" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteDataModelExport" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="HumanReadableBufferNames" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteGeneratorOutput" type="ENUMERATION" value="FULL"/>
+                <d:var name="RteCalibrationSupport" type="ENUMERATION" 
+                       value="NONE">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteCodeVendorId" type="INTEGER" value="0">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteDevErrorDetect" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="DisableInvalidationDataConsistency" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="DisablePartitionActiveChecks" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteDevErrorDetectUninit" type="BOOLEAN" 
+                       value="true">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteGenerationMode" type="ENUMERATION" 
+                       value="COMPATIBILITY_MODE">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteMeasurementSupport" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="OsSupportsSpinlockLockMethod" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteOptimizationMode" type="ENUMERATION" 
+                       value="MEMORY">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="OneSendSignalQueuePerCore" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteToolChainSignificantCharacters" type="INTEGER" 
+                       value="31">
+                  <a:a name="ENABLE" value="false"/>
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteValueRangeCheckEnabled" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:lst name="RteVfbTraceClientPrefix"/>
+                <d:var name="RteVfbTraceEnabled" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:lst name="RteVfbTraceFunction"/>
+                <d:var name="OsScheduleTableMaxExpiryPoints" type="INTEGER" 
+                       value="5000">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="OSEKCompatibilityMode" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="FunctionElision" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="UnconnectedRequirePorts" type="ENUMERATION" 
+                       value="Warning">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="DataConsistencyMechanism" type="ENUMERATION" 
+                       value="OsResource">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="InterruptBlockingFunction" type="ENUMERATION" 
+                       value="SuspendResumeAllInterrupts">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="ComCbkNotInterruptable" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="InterECUInvalidationHandledByRte" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="DirectReadFromCom" type="BOOLEAN" value="true">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteIocInteractionReturnValue" type="ENUMERATION" 
+                       value="RTE_IOC">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:ref name="OsCounterRef" type="REFERENCE" 
+                       value="ASPath:/Os/Os/Rte_Counter"/>
+                <d:var name="OsScheduleTableActivationMechanism" 
+                       type="ENUMERATION" value="RELATIVE">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="OsScheduleTableOffset" type="FLOAT" value="0.01">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:ref name="OsUserScheduleTableRef" type="REFERENCE" >
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:ref>
+                <d:var name="InterPartitionCommunication" type="ENUMERATION" 
+                       value="Disabled">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="GenerateEmptyRteStartStopStubs" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:ctr name="BswConfiguration" type="IDENTIFIABLE">
+                  <d:ref name="BswOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="BswOsTaskPeriod" type="FLOAT" value="0.1">
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:ref name="BswOsTaskRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="BswSendSignalQueueLength" type="INTEGER" 
+                         value="1">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="BswSendSignalGroupQueueLength" type="INTEGER" 
+                         value="1">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+                <d:ref name="SingleScheduleTablePartitionRef" type="REFERENCE" >
+                  <a:a name="ENABLE" value="false"/>
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:ref>
+                <d:lst name="CooperativeTasks" type="MAP"/>
+                <d:lst name="TaskChain" type="MAP"/>
+                <d:ctr name="OsCounterAssignments" type="IDENTIFIABLE">
+                  <a:a name="ENABLE" value="false"/>
+                  <d:lst name="OsCounterAssignment" type="MAP"/>
+                </d:ctr>
+                <d:var 
+                       name="GenerateRteFreedomFromInterferenceReviewInstructions" 
+                       type="BOOLEAN" value="false">
+                  <a:a name="ENABLE" value="false"/>
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="ExecuteTransformersDespiteLocalDataUnqueued" 
+                       type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="ExecuteTransformersDespiteLocalDataQueued" 
+                       type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var 
+                       name="InitializeImplicitWriteBufferBeforeRunnableExecutes" 
+                       type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+              </d:ctr>
+              <d:lst name="RteImplicitCommunication" type="MAP"/>
+              <d:lst name="RteInitializationBehavior" type="MAP"/>
+              <d:lst name="RteInitializationRunnableBatch" type="MAP"/>
+              <d:lst name="RteOsInteraction" type="MAP"/>
+              <d:lst name="RtePostBuildVariantConfiguration" type="MAP"/>
+              <d:ctr name="RteRips" type="IDENTIFIABLE">
+                <a:a name="ENABLE" value="false"/>
+                <d:var name="RteRipsSupport" type="ENUMERATION" 
+                       value="RTE_RIPS_OFF">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:lst name="RteRipsPluginConfigurationRef"/>
+              </d:ctr>
+              <d:lst name="RteSwComponentInstance" type="MAP">
+                <d:ctr name="SWC_ModifyEcho" type="IDENTIFIABLE">
+                  <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  <d:ctr name="DataMappings" type="IDENTIFIABLE">
+                    <a:a name="ENABLE" value="TRUE"/>
+                    <d:lst name="DataSRMapping" type="MAP">
+                      <d:ctr name="EcuMapping_1" type="IDENTIFIABLE">
+                        <d:ctr name="VariableDataPrototypeInstanceRef" 
+                               type="INSTANCE">
+                          <d:ref name="TARGET" type="REFERENCE" 
+                                 value="ASPath:/DemoApplication/PortInterfaces/If_Counter/CounterValue"/>
+                          <d:lst name="CONTEXT">
+                            <d:ref type="REFERENCE" 
+                                   value="ASPath:/DemoApplication/SwComponentTypes/SWC_ModifyEcho/R_NewCounterIn"/>
+                          </d:lst>
+                        </d:ctr>
+                        <d:chc name="DataSRKindMapping" type="IDENTIFIABLE" 
+                               value="DataSRPrimitive">
+                          <a:a name="IMPORTER_INFO" value="@DEF"/>
+                          <d:ctr name="DataSRPrimitive" type="IDENTIFIABLE">
+                            <d:ref name="SignalRef" type="REFERENCE" 
+                                   value="ASPath:/Com/Com/ComConfig/SGCounterIn_R"/>
+                          </d:ctr>
+                          <d:ctr name="DataSRComplex" type="IDENTIFIABLE">
+                            <d:ref name="SignalGroupRef" type="REFERENCE" >
+                              <a:a name="IMPORTER_INFO" value="@DEF"/>
+                            </d:ref>
+                            <d:lst name="SignalRef"/>
+                          </d:ctr>
+                        </d:chc>
+                      </d:ctr>
+                    </d:lst>
+                  </d:ctr>
+                  <d:ref name="MappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:ref name="RteSoftwareComponentInstanceRef" 
+                         type="REFERENCE" 
+                         value="ASPath:/EcuExtract/TopLevelComposition/SWC_ModifyEcho">
+                    <a:a name="ENABLE" value="TRUE"/>
+                    <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  </d:ref>
+                  <d:lst name="RteEventToTaskMapping" type="MAP">
+                    <d:ctr name="DataReceivedEvent" type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="1">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/DemoApplication/SwComponentTypes/SWC_ModifyEcho/IB_SWC_ModifyEcho/DataReceivedEvent"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/Rte_Event_Task">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteExclusiveAreaImplementation" type="MAP"/>
+                  <d:lst name="RteExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteNvRamAllocation" type="MAP"/>
+                </d:ctr>
+                <d:ctr name="SWC_CyclicCounter" type="IDENTIFIABLE">
+                  <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  <d:ctr name="DataMappings" type="IDENTIFIABLE">
+                    <a:a name="ENABLE" value="TRUE"/>
+                    <d:lst name="DataSRMapping" type="MAP">
+                      <d:ctr name="EcuMapping_2" type="IDENTIFIABLE">
+                        <d:ctr name="VariableDataPrototypeInstanceRef" 
+                               type="INSTANCE">
+                          <d:ref name="TARGET" type="REFERENCE" 
+                                 value="ASPath:/DemoApplication/PortInterfaces/If_Counter/CounterValue"/>
+                          <d:lst name="CONTEXT">
+                            <d:ref type="REFERENCE" 
+                                   value="ASPath:/DemoApplication/SwComponentTypes/SWC_CyclicCounter/P_CounterOut"/>
+                          </d:lst>
+                        </d:ctr>
+                        <d:chc name="DataSRKindMapping" type="IDENTIFIABLE" 
+                               value="DataSRPrimitive">
+                          <a:a name="IMPORTER_INFO" value="@DEF"/>
+                          <d:ctr name="DataSRPrimitive" type="IDENTIFIABLE">
+                            <d:ref name="SignalRef" type="REFERENCE" 
+                                   value="ASPath:/Com/Com/ComConfig/SGCounterOut_T"/>
+                          </d:ctr>
+                          <d:ctr name="DataSRComplex" type="IDENTIFIABLE">
+                            <d:ref name="SignalGroupRef" type="REFERENCE" >
+                              <a:a name="IMPORTER_INFO" value="@DEF"/>
+                            </d:ref>
+                            <d:lst name="SignalRef"/>
+                          </d:ctr>
+                        </d:chc>
+                      </d:ctr>
+                    </d:lst>
+                  </d:ctr>
+                  <d:ref name="MappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:ref name="RteSoftwareComponentInstanceRef" 
+                         type="REFERENCE" 
+                         value="ASPath:/EcuExtract/TopLevelComposition/SWC_CyclicCounter">
+                    <a:a name="ENABLE" value="TRUE"/>
+                    <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  </d:ref>
+                  <d:lst name="RteEventToTaskMapping" type="MAP">
+                    <d:ctr name="SetCounterOperationInvoked" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/DemoApplication/SwComponentTypes/SWC_CyclicCounter/IB_SWC_CyclicCounter/SetCounterOperationInvoked"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                    <d:ctr name="CyclicEvent" type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="1">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/DemoApplication/SwComponentTypes/SWC_CyclicCounter/IB_SWC_CyclicCounter/CyclicEvent"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/Rte_Time_Task">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                    <d:ctr name="ModeSwitchedRunTwo" type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="2">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/DemoApplication/SwComponentTypes/SWC_CyclicCounter/IB_SWC_CyclicCounter/ModeSwitchedRunTwo"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/Rte_Event_Task">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                    <d:ctr name="ModeSwitchedPrpShutdown" type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="3">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/DemoApplication/SwComponentTypes/SWC_CyclicCounter/IB_SWC_CyclicCounter/ModeSwitchedPrpShutdown"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/Rte_Event_Task">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteExclusiveAreaImplementation" type="MAP"/>
+                  <d:lst name="RteExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteNvRamAllocation" type="MAP"/>
+                </d:ctr>
+                <d:ctr name="SWC_IoHwAbs" type="IDENTIFIABLE">
+                  <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  <d:ctr name="DataMappings" type="IDENTIFIABLE">
+                    <a:a name="ENABLE" value="false"/>
+                    <d:lst name="DataSRMapping" type="MAP"/>
+                  </d:ctr>
+                  <d:ref name="MappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:ref name="RteSoftwareComponentInstanceRef" 
+                         type="REFERENCE" 
+                         value="ASPath:/EcuExtract/TopLevelComposition/SWC_IoHwAbs">
+                    <a:a name="ENABLE" value="TRUE"/>
+                    <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  </d:ref>
+                  <d:lst name="RteEventToTaskMapping" type="MAP">
+                    <d:ctr name="SetDiscreteValueOperationInvoked" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/DemoApplication/SwComponentTypes/SWC_IoHwAbs/IB_SWC_IoHwAbs/SetDiscreteValueOperationInvoked"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteExclusiveAreaImplementation" type="MAP"/>
+                  <d:lst name="RteExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteNvRamAllocation" type="MAP"/>
+                </d:ctr>
+                <d:ctr name="DevelopmentErrorTracer_Prototype" 
+                       type="IDENTIFIABLE">
+                  <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  <d:ctr name="DataMappings" type="IDENTIFIABLE">
+                    <a:a name="ENABLE" value="false"/>
+                    <d:lst name="DataSRMapping" type="MAP"/>
+                  </d:ctr>
+                  <d:ref name="MappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:ref name="RteSoftwareComponentInstanceRef" 
+                         type="REFERENCE" 
+                         value="ASPath:/EcuExtract/TopLevelComposition/DevelopmentErrorTracer_Prototype">
+                    <a:a name="ENABLE" value="TRUE"/>
+                    <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  </d:ref>
+                  <d:lst name="RteEventToTaskMapping" type="MAP">
+                    <d:ctr name="EV_ReportError_SWC_0" type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_Det/SwComponentTypes/DevelopmentErrorTracer/InternalBehavior/EV_ReportError_SWC_0"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteExclusiveAreaImplementation" type="MAP"/>
+                  <d:lst name="RteExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteNvRamAllocation" type="MAP"/>
+                </d:ctr>
+                <d:ctr name="ComM_Prototype" type="IDENTIFIABLE">
+                  <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  <d:ctr name="DataMappings" type="IDENTIFIABLE">
+                    <a:a name="ENABLE" value="false"/>
+                    <d:lst name="DataSRMapping" type="MAP"/>
+                  </d:ctr>
+                  <d:ref name="MappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:ref name="RteSoftwareComponentInstanceRef" 
+                         type="REFERENCE" 
+                         value="ASPath:/EcuExtract/TopLevelComposition/ComM_Prototype">
+                    <a:a name="ENABLE" value="TRUE"/>
+                    <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  </d:ref>
+                  <d:lst name="RteEventToTaskMapping" type="MAP">
+                    <d:ctr name="EV_RequestComMode_ComMUser_0" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_ComM/SwComponentTypes/ComM/SwcInternalBehavior_0/EV_RequestComMode_ComMUser_0"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                    <d:ctr name="EV_GetCurrentComMode_ComMUser_0" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_ComM/SwComponentTypes/ComM/SwcInternalBehavior_0/EV_GetCurrentComMode_ComMUser_0"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                    <d:ctr name="EV_GetCurrentPNCComMode_ComMUser_0" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_ComM/SwComponentTypes/ComM/SwcInternalBehavior_0/EV_GetCurrentPNCComMode_ComMUser_0"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                    <d:ctr name="EV_GetMaxComMode_ComMUser_0" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_ComM/SwComponentTypes/ComM/SwcInternalBehavior_0/EV_GetMaxComMode_ComMUser_0"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                    <d:ctr name="EV_GetRequestedComMode_ComMUser_0" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_ComM/SwComponentTypes/ComM/SwcInternalBehavior_0/EV_GetRequestedComMode_ComMUser_0"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteExclusiveAreaImplementation" type="MAP"/>
+                  <d:lst name="RteExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteNvRamAllocation" type="MAP"/>
+                </d:ctr>
+                <d:ctr name="BswM_Prototype" type="IDENTIFIABLE">
+                  <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  <d:ctr name="DataMappings" type="IDENTIFIABLE">
+                    <a:a name="ENABLE" value="false"/>
+                    <d:lst name="DataSRMapping" type="MAP"/>
+                  </d:ctr>
+                  <d:ref name="MappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:ref name="RteSoftwareComponentInstanceRef" 
+                         type="REFERENCE" 
+                         value="ASPath:/EcuExtract/TopLevelComposition/BswM_Prototype">
+                    <a:a name="ENABLE" value="TRUE"/>
+                    <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  </d:ref>
+                  <d:lst name="RteEventToTaskMapping" type="MAP"/>
+                  <d:lst name="RteEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteExclusiveAreaImplementation" type="MAP"/>
+                  <d:lst name="RteExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteNvRamAllocation" type="MAP"/>
+                </d:ctr>
+              </d:lst>
+              <d:lst name="RteSwComponentType" type="MAP">
+                <d:ctr name="RteSwComponentType_0" type="IDENTIFIABLE">
+                  <d:ref name="RteComponentTypeRef" type="REFERENCE" 
+                         value="ASPath:/DemoApplication/SwComponentTypes/SWC_ModifyEcho"/>
+                  <d:ref name="RteImplementationRef" type="REFERENCE" 
+                         value="ASPath:/DemoApplication/SwcImplementations/Impl_SWC_ModifyEcho">
+                    <a:a name="ENABLE" value="TRUE"/>
+                  </d:ref>
+                  <d:ctr name="RteComponentTypeCalibration" type="IDENTIFIABLE">
+                    <a:a name="ENABLE" value="false"/>
+                    <d:var name="RteCalibrationSupportEnabled" type="BOOLEAN" 
+                           value="true">
+                      <a:a name="IMPORTER_INFO" value="@DEF"/>
+                    </d:var>
+                    <d:lst name="RteCalibrationSwAddrMethodRef"/>
+                  </d:ctr>
+                </d:ctr>
+                <d:ctr name="RteSwComponentType_1" type="IDENTIFIABLE">
+                  <d:ref name="RteComponentTypeRef" type="REFERENCE" 
+                         value="ASPath:/DemoApplication/SwComponentTypes/SWC_CyclicCounter"/>
+                  <d:ref name="RteImplementationRef" type="REFERENCE" 
+                         value="ASPath:/DemoApplication/SwcImplementations/Impl_SWC_CyclicCounter">
+                    <a:a name="ENABLE" value="TRUE"/>
+                  </d:ref>
+                  <d:ctr name="RteComponentTypeCalibration" type="IDENTIFIABLE">
+                    <a:a name="ENABLE" value="false"/>
+                    <d:var name="RteCalibrationSupportEnabled" type="BOOLEAN" 
+                           value="true">
+                      <a:a name="IMPORTER_INFO" value="@DEF"/>
+                    </d:var>
+                    <d:lst name="RteCalibrationSwAddrMethodRef"/>
+                  </d:ctr>
+                </d:ctr>
+                <d:ctr name="RteSwComponentType_2" type="IDENTIFIABLE">
+                  <d:ref name="RteComponentTypeRef" type="REFERENCE" 
+                         value="ASPath:/DemoApplication/SwComponentTypes/SWC_IoHwAbs"/>
+                  <d:ref name="RteImplementationRef" type="REFERENCE" 
+                         value="ASPath:/DemoApplication/SwcImplementations/Impl_SWC_IoHwAbs">
+                    <a:a name="ENABLE" value="TRUE"/>
+                  </d:ref>
+                  <d:ctr name="RteComponentTypeCalibration" type="IDENTIFIABLE">
+                    <a:a name="ENABLE" value="false"/>
+                    <d:var name="RteCalibrationSupportEnabled" type="BOOLEAN" 
+                           value="true">
+                      <a:a name="IMPORTER_INFO" value="@DEF"/>
+                    </d:var>
+                    <d:lst name="RteCalibrationSwAddrMethodRef"/>
+                  </d:ctr>
+                </d:ctr>
+                <d:ctr name="RteSwComponentType_3" type="IDENTIFIABLE">
+                  <d:ref name="RteComponentTypeRef" type="REFERENCE" 
+                         value="ASPath:/AUTOSAR_Det/SwComponentTypes/DevelopmentErrorTracer"/>
+                  <d:ref name="RteImplementationRef" type="REFERENCE" 
+                         value="ASPath:/AUTOSAR_Det/Implementation">
+                    <a:a name="ENABLE" value="TRUE"/>
+                  </d:ref>
+                  <d:ctr name="RteComponentTypeCalibration" type="IDENTIFIABLE">
+                    <a:a name="ENABLE" value="false"/>
+                    <d:var name="RteCalibrationSupportEnabled" type="BOOLEAN" 
+                           value="true">
+                      <a:a name="IMPORTER_INFO" value="@DEF"/>
+                    </d:var>
+                    <d:lst name="RteCalibrationSwAddrMethodRef"/>
+                  </d:ctr>
+                </d:ctr>
+                <d:ctr name="RteSwComponentType_4" type="IDENTIFIABLE">
+                  <d:ref name="RteComponentTypeRef" type="REFERENCE" 
+                         value="ASPath:/AUTOSAR_ComM/SwComponentTypes/ComM"/>
+                  <d:ref name="RteImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_ComM/SwcImplementations/SwcImplementation_0">
+                    <a:a name="ENABLE" value="TRUE"/>
+                  </d:ref>
+                  <d:ctr name="RteComponentTypeCalibration" type="IDENTIFIABLE">
+                    <a:a name="ENABLE" value="false"/>
+                    <d:var name="RteCalibrationSupportEnabled" type="BOOLEAN" 
+                           value="true">
+                      <a:a name="IMPORTER_INFO" value="@DEF"/>
+                    </d:var>
+                    <d:lst name="RteCalibrationSwAddrMethodRef"/>
+                  </d:ctr>
+                </d:ctr>
+                <d:ctr name="RteSwComponentType_5" type="IDENTIFIABLE">
+                  <d:ref name="RteComponentTypeRef" type="REFERENCE" 
+                         value="ASPath:/AUTOSAR_BswM/SwComponentTypes/BswM"/>
+                  <d:ref name="RteImplementationRef" type="REFERENCE" 
+                         value="ASPath:/AUTOSAR_BswM/SwcImplementations/BswMImplementation">
+                    <a:a name="ENABLE" value="TRUE"/>
+                  </d:ref>
+                  <d:ctr name="RteComponentTypeCalibration" type="IDENTIFIABLE">
+                    <a:a name="ENABLE" value="false"/>
+                    <d:var name="RteCalibrationSupportEnabled" type="BOOLEAN" 
+                           value="true">
+                      <a:a name="IMPORTER_INFO" value="@DEF"/>
+                    </d:var>
+                    <d:lst name="RteCalibrationSwAddrMethodRef"/>
+                  </d:ctr>
+                </d:ctr>
+              </d:lst>
+            </d:ctr>
+          </d:chc>
+        </d:lst>
+      </d:ctr>
+    </d:lst>
+  </d:ctr>
+
+</datamodel>

--- a/tests/integration/data_files/simple_demo_mem_can_rte/config/MemIf.xdm
+++ b/tests/integration/data_files/simple_demo_mem_can_rte/config/MemIf.xdm
@@ -1,0 +1,82 @@
+<?xml version='1.0'?>
+<datamodel version="7.0" 
+           xmlns="http://www.tresos.de/_projects/DataModel2/16/root.xsd" 
+           xmlns:a="http://www.tresos.de/_projects/DataModel2/16/attribute.xsd" 
+           xmlns:v="http://www.tresos.de/_projects/DataModel2/06/schema.xsd" 
+           xmlns:d="http://www.tresos.de/_projects/DataModel2/06/data.xsd">
+
+  <d:ctr type="AUTOSAR" factory="autosar" 
+         xmlns:ad="http://www.tresos.de/_projects/DataModel2/08/admindata.xsd" 
+         xmlns:ce="http://www.tresos.de/_projects/DataModel2/18/childenable.xsd" 
+         xmlns:cd="http://www.tresos.de/_projects/DataModel2/08/customdata.xsd" 
+         xmlns:f="http://www.tresos.de/_projects/DataModel2/14/formulaexpr.xsd" 
+         xmlns:icc="http://www.tresos.de/_projects/DataModel2/08/implconfigclass.xsd" 
+         xmlns:mt="http://www.tresos.de/_projects/DataModel2/11/multitest.xsd"  
+         xmlns:variant="http://www.tresos.de/_projects/DataModel2/11/variant.xsd">
+    <d:lst type="TOP-LEVEL-PACKAGES">
+      <d:ctr name="MemIf" type="AR-PACKAGE">
+        <d:lst type="ELEMENTS">
+          <d:chc name="MemIf" type="AR-ELEMENT" value="MODULE-CONFIGURATION">
+            <d:ctr type="MODULE-CONFIGURATION">
+              <a:a name="DEF" value="ASPath:/TS_TxDxM5I11R0/MemIf"/>
+              <d:ctr name="CommonPublishedInformation" type="IDENTIFIABLE">
+                <d:var name="ArMajorVersion" type="INTEGER" value="1">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="ArMinorVersion" type="INTEGER" value="4">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="ArPatchVersion" type="INTEGER" value="0">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="SwMajorVersion" type="INTEGER" value="5">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="SwMinorVersion" type="INTEGER" value="11">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="SwPatchVersion" type="INTEGER" value="15"/>
+                <d:var name="ModuleId" type="INTEGER" value="22">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="VendorId" type="INTEGER" value="1">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="Release" type="STRING" value="">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+              </d:ctr>
+              <d:var name="IMPLEMENTATION_CONFIG_VARIANT" type="ENUMERATION" 
+                     value="VariantPreCompile">
+                <a:a name="IMPORTER_INFO" value="@DEF"/>
+              </d:var>
+              <d:ctr name="MemIfGeneral" type="IDENTIFIABLE">
+                <d:var name="MemIfMemAccUsage" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="MemIfDevErrorDetect" type="BOOLEAN" value="true">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="MemIfNumberOfDevices" type="INTEGER" value="1">
+                  <a:a name="IMPORTER_INFO">
+                    <a:v>@DEF</a:v>
+                    <a:v>@CALC</a:v>
+                  </a:a>
+                </d:var>
+                <d:var name="MemIfVersionInfoApi" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+              </d:ctr>
+              <d:ctr name="PublishedInformation" type="IDENTIFIABLE">
+                <d:var name="PbcfgMSupport" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+              </d:ctr>
+            </d:ctr>
+          </d:chc>
+        </d:lst>
+      </d:ctr>
+    </d:lst>
+  </d:ctr>
+
+</datamodel>

--- a/tests/integration/data_files/simple_demo_mem_can_rte/config/Rte.xdm
+++ b/tests/integration/data_files/simple_demo_mem_can_rte/config/Rte.xdm
@@ -1,0 +1,3495 @@
+<?xml version='1.0'?>
+<datamodel version="7.0" 
+           xmlns="http://www.tresos.de/_projects/DataModel2/16/root.xsd" 
+           xmlns:a="http://www.tresos.de/_projects/DataModel2/16/attribute.xsd" 
+           xmlns:v="http://www.tresos.de/_projects/DataModel2/06/schema.xsd" 
+           xmlns:d="http://www.tresos.de/_projects/DataModel2/06/data.xsd">
+
+  <d:ctr type="AUTOSAR" factory="autosar" 
+         xmlns:ad="http://www.tresos.de/_projects/DataModel2/08/admindata.xsd" 
+         xmlns:ce="http://www.tresos.de/_projects/DataModel2/18/childenable.xsd" 
+         xmlns:cd="http://www.tresos.de/_projects/DataModel2/08/customdata.xsd" 
+         xmlns:f="http://www.tresos.de/_projects/DataModel2/14/formulaexpr.xsd" 
+         xmlns:icc="http://www.tresos.de/_projects/DataModel2/08/implconfigclass.xsd" 
+         xmlns:mt="http://www.tresos.de/_projects/DataModel2/11/multitest.xsd"  
+         xmlns:variant="http://www.tresos.de/_projects/DataModel2/11/variant.xsd">
+    <d:lst type="TOP-LEVEL-PACKAGES">
+      <d:ctr name="Rte" type="AR-PACKAGE">
+        <d:lst type="ELEMENTS">
+          <d:chc name="Rte" type="AR-ELEMENT" value="MODULE-CONFIGURATION">
+            <d:ctr type="MODULE-CONFIGURATION">
+              <a:a name="DEF" value="ASPath:/TS_TxDxM6I9R0/Rte"/>
+              <d:ctr name="CommonPublishedInformation" type="IDENTIFIABLE">
+                <d:var name="ArMajorVersion" type="INTEGER" value="3"/>
+                <d:var name="ArMinorVersion" type="INTEGER" value="2"/>
+                <d:var name="ArPatchVersion" type="INTEGER" value="0"/>
+                <d:var name="SwMajorVersion" type="INTEGER" value="6"/>
+                <d:var name="SwMinorVersion" type="INTEGER" value="9"/>
+                <d:var name="SwPatchVersion" type="INTEGER" value="2"/>
+                <d:var name="ModuleId" type="INTEGER" value="2">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="VendorId" type="INTEGER" value="1">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="Release" type="STRING" value="">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+              </d:ctr>
+              <d:ctr name="PublishedInformation" type="IDENTIFIABLE">
+                <d:var name="PbcfgMSupport" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+              </d:ctr>
+              <d:var name="IMPLEMENTATION_CONFIG_VARIANT" type="ENUMERATION" 
+                     value="VariantPreCompile">
+                <a:a name="IMPORTER_INFO" value="@DEF"/>
+              </d:var>
+              <d:ctr name="RteBswGeneral" type="IDENTIFIABLE">
+                <d:var name="RteSchMVersionInfoApi" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteSchMOsScheduleTableActivationMechanism" 
+                       type="ENUMERATION" value="RELATIVE">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteSchMOsScheduleTableOffset" type="FLOAT" 
+                       value="0.01">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteUseComShadowSignalApi" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+              </d:ctr>
+              <d:lst name="RteBswModuleInstance" type="MAP">
+                <d:ctr name="BSW_BswM" type="IDENTIFIABLE">
+                  <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_BswM/Implementations/BswImplementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP">
+                    <d:ctr name="TimingEvent_MainFunction" type="IDENTIFIABLE">
+                      <a:a name="IMPORTER_INFO" value="@CALC"/>
+                      <d:var name="RteBswActivationOffset" type="FLOAT" 
+                             value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPositionInTask" type="INTEGER" 
+                             value="2">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteBswServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_BswM/BswModuleDescriptions/BswM/InternalBehavior_0/TimingEvent_MainFunction">
+                        <a:a name="IMPORTER_INFO" value="@CALC"/>
+                      </d:ref>
+                      <d:ref name="RteBswMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/SchMDiagStateTask_20ms">
+                        <a:a name="ENABLE" value="TRUE"/>
+                        <a:a name="IMPORTER_INFO" value="@CALC"/>
+                      </d:ref>
+                      <d:var name="RteBswAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="true"/>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                </d:ctr>
+                <d:ctr name="BSW_EcuM" type="IDENTIFIABLE">
+                  <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_EcuM/Implementations/BswImplementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP">
+                    <d:ctr name="TimingEvent_MainFunction" type="IDENTIFIABLE">
+                      <a:a name="IMPORTER_INFO" value="@CALC"/>
+                      <d:var name="RteBswActivationOffset" type="FLOAT" 
+                             value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPositionInTask" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteBswServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_EcuM/BswModuleDescriptions/EcuM/InternalBehavior_0/TimingEvent_MainFunction">
+                        <a:a name="IMPORTER_INFO" value="@CALC"/>
+                      </d:ref>
+                      <d:ref name="RteBswMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/SchMDiagStateTask_20ms">
+                        <a:a name="ENABLE" value="TRUE"/>
+                        <a:a name="IMPORTER_INFO" value="@CALC"/>
+                      </d:ref>
+                      <d:var name="RteBswAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                </d:ctr>
+                <d:ctr name="BSW_Dem" type="IDENTIFIABLE">
+                  <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_Dem/Implementations/BswImplementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP">
+                    <d:ctr name="TimingEvent_MainFunction" type="IDENTIFIABLE">
+                      <a:a name="IMPORTER_INFO" value="@CALC"/>
+                      <d:var name="RteBswActivationOffset" type="FLOAT" 
+                             value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPositionInTask" type="INTEGER" 
+                             value="3">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteBswServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_Dem/BswModuleDescriptions/Dem/InternalBehavior_0/TimingEvent_MainFunction">
+                        <a:a name="IMPORTER_INFO" value="@CALC"/>
+                      </d:ref>
+                      <d:ref name="RteBswMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/SchMDiagStateTask_20ms">
+                        <a:a name="ENABLE" value="TRUE"/>
+                        <a:a name="IMPORTER_INFO" value="@CALC"/>
+                      </d:ref>
+                      <d:var name="RteBswAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                </d:ctr>
+                <d:ctr name="BSW_Det" type="IDENTIFIABLE">
+                  <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_Det/Implementations/BswImplementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP"/>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                </d:ctr>
+                <d:ctr name="BSW_PbcfgM" type="IDENTIFIABLE">
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_PbcfgM/Implementations/BswImplementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP"/>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+                <d:ctr name="BSW_Atomics" type="IDENTIFIABLE">
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_Atomics/Implementations/BswImplementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP"/>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+                <d:ctr name="BSW_Base" type="IDENTIFIABLE">
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_Base/Implementations/BswImplementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP"/>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+                <d:ctr name="BSW_CanIf" type="IDENTIFIABLE">
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_CanIf/Implementations/BswImplementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP"/>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+                <d:ctr name="BSW_CanSM" type="IDENTIFIABLE">
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_CanSM/Implementations/BswImplementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP">
+                    <d:ctr name="TimingEvent_MainFunction" type="IDENTIFIABLE">
+                      <d:var name="RteBswActivationOffset" type="FLOAT" 
+                             value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPositionInTask" type="INTEGER" 
+                             value="5">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteBswServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_CanSM/BswModuleDescriptions/CanSM/InternalBehavior_0/TimingEvent_MainFunction"/>
+                      <d:ref name="RteBswMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/SchMDiagStateTask_20ms">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:ref>
+                      <d:var name="RteBswAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+                <d:ctr name="BSW_Can" type="IDENTIFIABLE">
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_Can/Implementations/BswImplementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP">
+                    <d:ctr name="TimingEvent_MainFunction_Mode" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteBswActivationOffset" type="FLOAT" 
+                             value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPositionInTask" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteBswServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_Can/BswModuleDescriptions/Can/InternalBehavior_0/TimingEvent_MainFunction_Mode"/>
+                      <d:ref name="RteBswMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/SchMComTask_5ms">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:ref>
+                      <d:var name="RteBswAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+                <d:ctr name="BSW_ComM" type="IDENTIFIABLE">
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_ComM/Implementations/BswImplementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP">
+                    <d:ctr name="TimingEvent_MainFunction_0" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteBswActivationOffset" type="FLOAT" 
+                             value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPositionInTask" type="INTEGER" 
+                             value="4">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteBswServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_ComM/BswModuleDescriptions/ComM/InternalBehavior_0/TimingEvent_MainFunction_0"/>
+                      <d:ref name="RteBswMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/SchMDiagStateTask_20ms">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:ref>
+                      <d:var name="RteBswAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+                <d:ctr name="BSW_Com" type="IDENTIFIABLE">
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_Com/Implementations/Implementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP">
+                    <d:ctr name="TimingEvent_MainFunctionRx" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteBswActivationOffset" type="FLOAT" 
+                             value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPositionInTask" type="INTEGER" 
+                             value="2">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteBswServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_Com/BswModuleDescriptions/Com/BswImplementation_0/TimingEvent_MainFunctionRx"/>
+                      <d:ref name="RteBswMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/SchMComTask_5ms">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:ref>
+                      <d:var name="RteBswAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                    </d:ctr>
+                    <d:ctr name="TimingEvent_MainFunctionTx" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteBswActivationOffset" type="FLOAT" 
+                             value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPositionInTask" type="INTEGER" 
+                             value="4">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteBswServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_Com/BswModuleDescriptions/Com/BswImplementation_0/TimingEvent_MainFunctionTx"/>
+                      <d:ref name="RteBswMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/SchMComTask_5ms">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:ref>
+                      <d:var name="RteBswAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                    </d:ctr>
+                    <d:ctr name="TimingEvent_MainFunctionRouteSignals" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteBswActivationOffset" type="FLOAT" 
+                             value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPositionInTask" type="INTEGER" 
+                             value="3">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteBswServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_Com/BswModuleDescriptions/Com/BswImplementation_0/TimingEvent_MainFunctionRouteSignals"/>
+                      <d:ref name="RteBswMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/SchMComTask_5ms">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:ref>
+                      <d:var name="RteBswAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+                <d:ctr name="BSW_PduR" type="IDENTIFIABLE">
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_PduR/Implementations/BswImplementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP"/>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+                <d:ctr name="BSW_Crc" type="IDENTIFIABLE">
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_Crc/Implementations/BswImplementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP"/>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+                <d:ctr name="BSW_Ea" type="IDENTIFIABLE">
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_Ea/Implementations/BswImplementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP">
+                    <d:ctr name="TimingEvent_MainFunction" type="IDENTIFIABLE">
+                      <d:var name="RteBswActivationOffset" type="FLOAT" 
+                             value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPositionInTask" type="INTEGER" 
+                             value="2">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteBswServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_Ea/BswModuleDescriptions/Ea/InternalBehavior_0/TimingEvent_MainFunction"/>
+                      <d:ref name="RteBswMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/SchMMemTask_10ms">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:ref>
+                      <d:var name="RteBswAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+                <d:ctr name="BSW_Eep" type="IDENTIFIABLE">
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_Eep/Implementations/BswImplementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP">
+                    <d:ctr name="TimingEvent_MainFunction" type="IDENTIFIABLE">
+                      <d:var name="RteBswActivationOffset" type="FLOAT" 
+                             value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPositionInTask" type="INTEGER" 
+                             value="3">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteBswServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_Eep/BswModuleDescriptions/Eep/InternalBehavior_0/TimingEvent_MainFunction"/>
+                      <d:ref name="RteBswMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/SchMMemTask_10ms">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:ref>
+                      <d:var name="RteBswAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+                <d:ctr name="BSW_MemIf" type="IDENTIFIABLE">
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_MemIf/Implementations/BswImplementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP"/>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+                <d:ctr name="BSW_NvM" type="IDENTIFIABLE">
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_NvM/Implementations/BswImplementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP">
+                    <d:ctr name="TimingEvent_MainFunction" type="IDENTIFIABLE">
+                      <d:var name="RteBswActivationOffset" type="FLOAT" 
+                             value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteBswPositionInTask" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteBswServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_NvM/BswModuleDescriptions/NvM/InternalBehavior_0/TimingEvent_MainFunction"/>
+                      <d:ref name="RteBswMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/SchMMemTask_10ms">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:ref>
+                      <d:var name="RteBswAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteBswUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteBswUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+                <d:ctr name="BSW_EcuC" type="IDENTIFIABLE">
+                  <d:ref name="RteBswImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_EcuC/Implementations/BswImplementation_0"/>
+                  <d:ref name="RteBswModuleConfigurationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:lst name="RteBswEventToTaskMapping" type="MAP"/>
+                  <d:lst name="RteBswEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteBswExclusiveAreaImpl" type="MAP"/>
+                  <d:lst name="RteBswExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteBswRequiredModeGroupConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredSenderReceiverConnection" 
+                         type="MAP"/>
+                  <d:lst name="RteBswRequiredClientServerConnection" type="MAP"/>
+                  <d:lst name="RteBswRequiredTriggerConnection" type="MAP"/>
+                  <d:ref name="RteMappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="ASR31SchMExclusiveAreaAPISupport" type="BOOLEAN" 
+                         value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="ASR31SchMExclusiveAreaAPIUseInstanceParameter" 
+                         type="BOOLEAN" value="false">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+              </d:lst>
+              <d:ctr name="RteGeneration" type="IDENTIFIABLE">
+                <d:var name="ASR32RteWrapper" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="GenerateTimestamp" type="BOOLEAN" value="true">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="OverrideXfBufferComputation" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:lst name="ComTaskConfiguration" type="MAP"/>
+                <d:var name="BswmdOutputDirectory" type="STRING" >
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="OptimizeCdsGeneration" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RespectConfiguredTaskType" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="SpinlockAllocationStrategy" type="ENUMERATION" 
+                       value="OnePerChannel">
+                  <a:a name="ENABLE" value="false"/>
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="SendSignalQueueStrategy" type="ENUMERATION" 
+                       value="Global">
+                  <a:a name="IMPORTER_INFO">
+                    <a:v>@DEF</a:v>
+                    <a:v>@CALC</a:v>
+                  </a:a>
+                </d:var>
+                <d:var name="OneScheduleTablePerPartition" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteDataModelExport" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="HumanReadableBufferNames" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteGeneratorOutput" type="ENUMERATION" value="FULL"/>
+                <d:var name="RteCalibrationSupport" type="ENUMERATION" 
+                       value="NONE">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteCodeVendorId" type="INTEGER" value="0">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteDevErrorDetect" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="DisableInvalidationDataConsistency" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="DisablePartitionActiveChecks" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteDevErrorDetectUninit" type="BOOLEAN" 
+                       value="true">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteGenerationMode" type="ENUMERATION" 
+                       value="COMPATIBILITY_MODE">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteMeasurementSupport" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="OsSupportsSpinlockLockMethod" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteOptimizationMode" type="ENUMERATION" 
+                       value="MEMORY">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="OneSendSignalQueuePerCore" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteToolChainSignificantCharacters" type="INTEGER" 
+                       value="31">
+                  <a:a name="ENABLE" value="false"/>
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteValueRangeCheckEnabled" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:lst name="RteVfbTraceClientPrefix"/>
+                <d:var name="RteVfbTraceEnabled" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:lst name="RteVfbTraceFunction"/>
+                <d:var name="OsScheduleTableMaxExpiryPoints" type="INTEGER" 
+                       value="5000">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="OSEKCompatibilityMode" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="FunctionElision" type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="UnconnectedRequirePorts" type="ENUMERATION" 
+                       value="Warning">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="DataConsistencyMechanism" type="ENUMERATION" 
+                       value="OsResource">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="InterruptBlockingFunction" type="ENUMERATION" 
+                       value="SuspendResumeAllInterrupts">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="ComCbkNotInterruptable" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="InterECUInvalidationHandledByRte" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="DirectReadFromCom" type="BOOLEAN" value="true">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="RteIocInteractionReturnValue" type="ENUMERATION" 
+                       value="RTE_IOC">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:ref name="OsCounterRef" type="REFERENCE" 
+                       value="ASPath:/Os/Os/Rte_Counter"/>
+                <d:var name="OsScheduleTableActivationMechanism" 
+                       type="ENUMERATION" value="RELATIVE">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="OsScheduleTableOffset" type="FLOAT" value="0.01">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:ref name="OsUserScheduleTableRef" type="REFERENCE" >
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:ref>
+                <d:var name="InterPartitionCommunication" type="ENUMERATION" 
+                       value="Disabled">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="GenerateEmptyRteStartStopStubs" type="BOOLEAN" 
+                       value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:ctr name="BswConfiguration" type="IDENTIFIABLE">
+                  <d:ref name="BswOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="BswOsTaskPeriod" type="FLOAT" value="0.1">
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:ref name="BswOsTaskRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:var name="BswSendSignalQueueLength" type="INTEGER" 
+                         value="1">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                  <d:var name="BswSendSignalGroupQueueLength" type="INTEGER" 
+                         value="1">
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:var>
+                </d:ctr>
+                <d:ref name="SingleScheduleTablePartitionRef" type="REFERENCE" >
+                  <a:a name="ENABLE" value="false"/>
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:ref>
+                <d:lst name="CooperativeTasks" type="MAP"/>
+                <d:lst name="TaskChain" type="MAP"/>
+                <d:ctr name="OsCounterAssignments" type="IDENTIFIABLE">
+                  <a:a name="ENABLE" value="false"/>
+                  <d:lst name="OsCounterAssignment" type="MAP"/>
+                </d:ctr>
+                <d:var 
+                       name="GenerateRteFreedomFromInterferenceReviewInstructions" 
+                       type="BOOLEAN" value="false">
+                  <a:a name="ENABLE" value="false"/>
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="ExecuteTransformersDespiteLocalDataUnqueued" 
+                       type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var name="ExecuteTransformersDespiteLocalDataQueued" 
+                       type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:var 
+                       name="InitializeImplicitWriteBufferBeforeRunnableExecutes" 
+                       type="BOOLEAN" value="false">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+              </d:ctr>
+              <d:lst name="RteImplicitCommunication" type="MAP"/>
+              <d:lst name="RteInitializationBehavior" type="MAP"/>
+              <d:lst name="RteInitializationRunnableBatch" type="MAP"/>
+              <d:lst name="RteOsInteraction" type="MAP"/>
+              <d:lst name="RtePostBuildVariantConfiguration" type="MAP"/>
+              <d:ctr name="RteRips" type="IDENTIFIABLE">
+                <a:a name="ENABLE" value="false"/>
+                <d:var name="RteRipsSupport" type="ENUMERATION" 
+                       value="RTE_RIPS_OFF">
+                  <a:a name="IMPORTER_INFO" value="@DEF"/>
+                </d:var>
+                <d:lst name="RteRipsPluginConfigurationRef"/>
+              </d:ctr>
+              <d:lst name="RteSwComponentInstance" type="MAP">
+                <d:ctr name="SWC_ModifyEcho" type="IDENTIFIABLE">
+                  <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  <d:ctr name="DataMappings" type="IDENTIFIABLE">
+                    <a:a name="ENABLE" value="TRUE"/>
+                    <d:lst name="DataSRMapping" type="MAP">
+                      <d:ctr name="EcuMapping_1" type="IDENTIFIABLE">
+                        <d:ctr name="VariableDataPrototypeInstanceRef" 
+                               type="INSTANCE">
+                          <d:ref name="TARGET" type="REFERENCE" 
+                                 value="ASPath:/DemoApplication/PortInterfaces/If_Counter/CounterValue"/>
+                          <d:lst name="CONTEXT">
+                            <d:ref type="REFERENCE" 
+                                   value="ASPath:/DemoApplication/SwComponentTypes/SWC_ModifyEcho/R_NewCounterIn"/>
+                          </d:lst>
+                        </d:ctr>
+                        <d:chc name="DataSRKindMapping" type="IDENTIFIABLE" 
+                               value="DataSRPrimitive">
+                          <a:a name="IMPORTER_INFO" value="@DEF"/>
+                          <d:ctr name="DataSRPrimitive" type="IDENTIFIABLE">
+                            <d:ref name="SignalRef" type="REFERENCE" 
+                                   value="ASPath:/Com/Com/ComConfig/SGCounterIn_256R"/>
+                          </d:ctr>
+                          <d:ctr name="DataSRComplex" type="IDENTIFIABLE">
+                            <d:ref name="SignalGroupRef" type="REFERENCE" >
+                              <a:a name="IMPORTER_INFO" value="@DEF"/>
+                            </d:ref>
+                            <d:lst name="SignalRef"/>
+                          </d:ctr>
+                        </d:chc>
+                      </d:ctr>
+                    </d:lst>
+                  </d:ctr>
+                  <d:ref name="MappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:ref name="RteSoftwareComponentInstanceRef" 
+                         type="REFERENCE" 
+                         value="ASPath:/EcuExtract/TopLevelComposition/SWC_ModifyEcho">
+                    <a:a name="ENABLE" value="TRUE"/>
+                    <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  </d:ref>
+                  <d:lst name="RteEventToTaskMapping" type="MAP">
+                    <d:ctr name="DataReceivedEvent" type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="1">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/DemoApplication/SwComponentTypes/SWC_ModifyEcho/IB_SWC_ModifyEcho/DataReceivedEvent"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/Rte_Event_Task">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteExclusiveAreaImplementation" type="MAP"/>
+                  <d:lst name="RteExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteNvRamAllocation" type="MAP"/>
+                </d:ctr>
+                <d:ctr name="SWC_CyclicCounter" type="IDENTIFIABLE">
+                  <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  <d:ctr name="DataMappings" type="IDENTIFIABLE">
+                    <a:a name="ENABLE" value="TRUE"/>
+                    <d:lst name="DataSRMapping" type="MAP">
+                      <d:ctr name="EcuMapping_2" type="IDENTIFIABLE">
+                        <d:ctr name="VariableDataPrototypeInstanceRef" 
+                               type="INSTANCE">
+                          <d:ref name="TARGET" type="REFERENCE" 
+                                 value="ASPath:/DemoApplication/PortInterfaces/If_Counter/CounterValue"/>
+                          <d:lst name="CONTEXT">
+                            <d:ref type="REFERENCE" 
+                                   value="ASPath:/DemoApplication/SwComponentTypes/SWC_CyclicCounter/P_CounterOut"/>
+                          </d:lst>
+                        </d:ctr>
+                        <d:chc name="DataSRKindMapping" type="IDENTIFIABLE" 
+                               value="DataSRPrimitive">
+                          <a:a name="IMPORTER_INFO" value="@DEF"/>
+                          <d:ctr name="DataSRPrimitive" type="IDENTIFIABLE">
+                            <d:ref name="SignalRef" type="REFERENCE" 
+                                   value="ASPath:/Com/Com/ComConfig/SGCounterOut_272T"/>
+                          </d:ctr>
+                          <d:ctr name="DataSRComplex" type="IDENTIFIABLE">
+                            <d:ref name="SignalGroupRef" type="REFERENCE" >
+                              <a:a name="IMPORTER_INFO" value="@DEF"/>
+                            </d:ref>
+                            <d:lst name="SignalRef"/>
+                          </d:ctr>
+                        </d:chc>
+                      </d:ctr>
+                    </d:lst>
+                  </d:ctr>
+                  <d:ref name="MappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:ref name="RteSoftwareComponentInstanceRef" 
+                         type="REFERENCE" 
+                         value="ASPath:/EcuExtract/TopLevelComposition/SWC_CyclicCounter">
+                    <a:a name="ENABLE" value="TRUE"/>
+                    <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  </d:ref>
+                  <d:lst name="RteEventToTaskMapping" type="MAP">
+                    <d:ctr name="SetCounterOperationInvoked" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/DemoApplication/SwComponentTypes/SWC_CyclicCounter/IB_SWC_CyclicCounter/SetCounterOperationInvoked"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                    <d:ctr name="CyclicEvent" type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="1">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/DemoApplication/SwComponentTypes/SWC_CyclicCounter/IB_SWC_CyclicCounter/CyclicEvent"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/Rte_Time_Task">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                    <d:ctr name="ModeSwitchedRunTwo" type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="2">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/DemoApplication/SwComponentTypes/SWC_CyclicCounter/IB_SWC_CyclicCounter/ModeSwitchedRunTwo"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/Rte_Event_Task">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                    <d:ctr name="ModeSwitchedPrpShutdown" type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="3">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/DemoApplication/SwComponentTypes/SWC_CyclicCounter/IB_SWC_CyclicCounter/ModeSwitchedPrpShutdown"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" 
+                             value="ASPath:/Os/Os/Rte_Event_Task">
+                        <a:a name="ENABLE" value="TRUE"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteExclusiveAreaImplementation" type="MAP"/>
+                  <d:lst name="RteExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteNvRamAllocation" type="MAP">
+                    <d:ctr name="ServiceDependency" type="IDENTIFIABLE">
+                      <a:a name="IMPORTER_INFO" value="@CALC"/>
+                      <d:var name="RteNvmRamBlockLocationSymbol" 
+                             type="LINKER-SYMBOL" 
+                             value="Demo_CyclicCounter_Ram_Block">
+                        <a:a name="ENABLE" value="TRUE"/>
+                        <a:a name="IMPORTER_INFO" value="@CALC"/>
+                      </d:var>
+                      <d:var name="RteNvmRomBlockLocationSymbol" 
+                             type="LINKER-SYMBOL" 
+                             value="Demo_CyclicCounter_Rom_Block">
+                        <a:a name="ENABLE" value="TRUE"/>
+                        <a:a name="IMPORTER_INFO" value="@CALC"/>
+                      </d:var>
+                      <d:ref name="RteSwNvRamMappingRef" type="REFERENCE" 
+                             value="ASPath:/DemoApplication/SwComponentTypes/SWC_CyclicCounter/IB_SWC_CyclicCounter/ServiceDependency">
+                        <a:a name="ENABLE" value="true"/>
+                        <a:a name="IMPORTER_INFO" value="@CALC"/>
+                      </d:ref>
+                      <d:ref name="RteNvmBlockRef" type="REFERENCE" 
+                             value="ASPath:/NvM/NvM/PersistentCounterValue">
+                        <a:a name="IMPORTER_INFO" value="@CALC"/>
+                      </d:ref>
+                      <d:ref name="RteSwNvBlockDescriptorRef" type="REFERENCE" 
+                             value="ASPath:/NvM/NvMBlockDescriptor/PersistentCounterValue/Demo_CyclicCounter_Rom_Block"/>
+                    </d:ctr>
+                  </d:lst>
+                </d:ctr>
+                <d:ctr name="SWC_IoHwAbs" type="IDENTIFIABLE">
+                  <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  <d:ctr name="DataMappings" type="IDENTIFIABLE">
+                    <a:a name="ENABLE" value="false"/>
+                    <d:lst name="DataSRMapping" type="MAP"/>
+                  </d:ctr>
+                  <d:ref name="MappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:ref name="RteSoftwareComponentInstanceRef" 
+                         type="REFERENCE" 
+                         value="ASPath:/EcuExtract/TopLevelComposition/SWC_IoHwAbs">
+                    <a:a name="ENABLE" value="TRUE"/>
+                    <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  </d:ref>
+                  <d:lst name="RteEventToTaskMapping" type="MAP">
+                    <d:ctr name="SetDiscreteValueOperationInvoked" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/DemoApplication/SwComponentTypes/SWC_IoHwAbs/IB_SWC_IoHwAbs/SetDiscreteValueOperationInvoked"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteExclusiveAreaImplementation" type="MAP"/>
+                  <d:lst name="RteExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteNvRamAllocation" type="MAP"/>
+                </d:ctr>
+                <d:ctr name="DevelopmentErrorTracer_Prototype" 
+                       type="IDENTIFIABLE">
+                  <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  <d:ctr name="DataMappings" type="IDENTIFIABLE">
+                    <a:a name="ENABLE" value="false"/>
+                    <d:lst name="DataSRMapping" type="MAP"/>
+                  </d:ctr>
+                  <d:ref name="MappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:ref name="RteSoftwareComponentInstanceRef" 
+                         type="REFERENCE" 
+                         value="ASPath:/EcuExtract/TopLevelComposition/DevelopmentErrorTracer_Prototype">
+                    <a:a name="ENABLE" value="TRUE"/>
+                    <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  </d:ref>
+                  <d:lst name="RteEventToTaskMapping" type="MAP">
+                    <d:ctr name="EV_ReportError_SWC_0" type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_Det/SwComponentTypes/DevelopmentErrorTracer/InternalBehavior/EV_ReportError_SWC_0"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteExclusiveAreaImplementation" type="MAP"/>
+                  <d:lst name="RteExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteNvRamAllocation" type="MAP"/>
+                </d:ctr>
+                <d:ctr name="BswM_Prototype" type="IDENTIFIABLE">
+                  <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  <d:ctr name="DataMappings" type="IDENTIFIABLE">
+                    <a:a name="ENABLE" value="false"/>
+                    <d:lst name="DataSRMapping" type="MAP"/>
+                  </d:ctr>
+                  <d:ref name="MappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:ref name="RteSoftwareComponentInstanceRef" 
+                         type="REFERENCE" 
+                         value="ASPath:/EcuExtract/TopLevelComposition/BswM_Prototype">
+                    <a:a name="ENABLE" value="TRUE"/>
+                    <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  </d:ref>
+                  <d:lst name="RteEventToTaskMapping" type="MAP"/>
+                  <d:lst name="RteEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteExclusiveAreaImplementation" type="MAP"/>
+                  <d:lst name="RteExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteNvRamAllocation" type="MAP"/>
+                </d:ctr>
+                <d:ctr name="ComM_Prototype" type="IDENTIFIABLE">
+                  <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  <d:ctr name="DataMappings" type="IDENTIFIABLE">
+                    <a:a name="ENABLE" value="false"/>
+                    <d:lst name="DataSRMapping" type="MAP"/>
+                  </d:ctr>
+                  <d:ref name="MappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:ref name="RteSoftwareComponentInstanceRef" 
+                         type="REFERENCE" 
+                         value="ASPath:/EcuExtract/TopLevelComposition/ComM_Prototype">
+                    <a:a name="ENABLE" value="TRUE"/>
+                    <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  </d:ref>
+                  <d:lst name="RteEventToTaskMapping" type="MAP">
+                    <d:ctr name="EV_RequestComMode_ComMUser_0" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_ComM/SwComponentTypes/ComM/SwcInternalBehavior_0/EV_RequestComMode_ComMUser_0"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                    <d:ctr name="EV_GetCurrentComMode_ComMUser_0" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_ComM/SwComponentTypes/ComM/SwcInternalBehavior_0/EV_GetCurrentComMode_ComMUser_0"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                    <d:ctr name="EV_GetMaxComMode_ComMUser_0" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_ComM/SwComponentTypes/ComM/SwcInternalBehavior_0/EV_GetMaxComMode_ComMUser_0"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                    <d:ctr name="EV_GetRequestedComMode_ComMUser_0" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_ComM/SwComponentTypes/ComM/SwcInternalBehavior_0/EV_GetRequestedComMode_ComMUser_0"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteExclusiveAreaImplementation" type="MAP"/>
+                  <d:lst name="RteExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteNvRamAllocation" type="MAP"/>
+                </d:ctr>
+                <d:ctr name="NvM_Prototype" type="IDENTIFIABLE">
+                  <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  <d:ctr name="DataMappings" type="IDENTIFIABLE">
+                    <a:a name="ENABLE" value="false"/>
+                    <d:lst name="DataSRMapping" type="MAP"/>
+                  </d:ctr>
+                  <d:ref name="MappedToOsApplicationRef" type="REFERENCE" >
+                    <a:a name="ENABLE" value="false"/>
+                    <a:a name="IMPORTER_INFO" value="@DEF"/>
+                  </d:ref>
+                  <d:ref name="RteSoftwareComponentInstanceRef" 
+                         type="REFERENCE" 
+                         value="ASPath:/EcuExtract/TopLevelComposition/NvM_Prototype">
+                    <a:a name="ENABLE" value="TRUE"/>
+                    <a:a name="IMPORTER_INFO" value="@CALC"/>
+                  </d:ref>
+                  <d:lst name="RteEventToTaskMapping" type="MAP">
+                    <d:ctr name="EV_GetErrorStatus_PersistentCounterValue" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_NvM/SwComponentTypes/NvM/NvMIntBeh/EV_GetErrorStatus_PersistentCounterValue"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                    <d:ctr name="EV_SetDataIndex_PersistentCounterValue" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_NvM/SwComponentTypes/NvM/NvMIntBeh/EV_SetDataIndex_PersistentCounterValue"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                    <d:ctr name="EV_GetDataIndex_PersistentCounterValue" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_NvM/SwComponentTypes/NvM/NvMIntBeh/EV_GetDataIndex_PersistentCounterValue"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                    <d:ctr name="EV_SetRamBlockStatus_PersistentCounterValue" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_NvM/SwComponentTypes/NvM/NvMIntBeh/EV_SetRamBlockStatus_PersistentCounterValue"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                    <d:ctr name="EV_ReadBlock_PersistentCounterValue" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_NvM/SwComponentTypes/NvM/NvMIntBeh/EV_ReadBlock_PersistentCounterValue"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                    <d:ctr name="EV_WriteBlock_PersistentCounterValue" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_NvM/SwComponentTypes/NvM/NvMIntBeh/EV_WriteBlock_PersistentCounterValue"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                    <d:ctr 
+                           name="EV_RestoreBlockDefaults_PersistentCounterValue" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_NvM/SwComponentTypes/NvM/NvMIntBeh/EV_RestoreBlockDefaults_PersistentCounterValue"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                    <d:ctr name="EV_EraseBlock_PersistentCounterValue" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_NvM/SwComponentTypes/NvM/NvMIntBeh/EV_EraseBlock_PersistentCounterValue"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                    <d:ctr name="EV_InvalidateNvBlock_PersistentCounterValue" 
+                           type="IDENTIFIABLE">
+                      <d:var name="RteActivationOffset" type="FLOAT" value="0.0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePeriod" type="FLOAT" value="0.1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteImmediateRestart" type="BOOLEAN" 
+                             value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteOsSchedulePoint" type="ENUMERATION" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RtePositionInTask" type="INTEGER" value="0">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteServerQueueLength" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:var name="RteMaxNrOfProcessedRequests" type="INTEGER" 
+                             value="1">
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteEventRef" type="REFERENCE" 
+                             value="ASPath:/AUTOSAR_NvM/SwComponentTypes/NvM/NvMIntBeh/EV_InvalidateNvBlock_PersistentCounterValue"/>
+                      <d:ref name="RteMappedToTaskRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:var name="RteAllowInterPartitionDirectCall" 
+                             type="BOOLEAN" value="false">
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:var>
+                      <d:ref name="RteRipsFillRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsFlushRoutineRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteRipsInvocationHandlerRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                      </d:ref>
+                      <d:ref name="RteUsedInitFnc" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsAlarmRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsEventRef" type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteUsedOsSchTblExpiryPointRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                      <d:ref name="RteVirtuallyMappedToTaskRef" 
+                             type="REFERENCE" >
+                        <a:a name="ENABLE" value="false"/>
+                        <a:a name="IMPORTER_INFO" value="@DEF"/>
+                      </d:ref>
+                    </d:ctr>
+                  </d:lst>
+                  <d:lst name="RteEventToIsrMapping" type="MAP"/>
+                  <d:lst name="RteExclusiveAreaImplementation" type="MAP"/>
+                  <d:lst name="RteExternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteInternalTriggerConfig" type="MAP"/>
+                  <d:lst name="RteNvRamAllocation" type="MAP"/>
+                </d:ctr>
+              </d:lst>
+              <d:lst name="RteSwComponentType" type="MAP">
+                <d:ctr name="RteSwComponentType_0" type="IDENTIFIABLE">
+                  <d:ref name="RteComponentTypeRef" type="REFERENCE" 
+                         value="ASPath:/DemoApplication/SwComponentTypes/SWC_ModifyEcho"/>
+                  <d:ref name="RteImplementationRef" type="REFERENCE" 
+                         value="ASPath:/DemoApplication/SwcImplementations/Impl_SWC_ModifyEcho">
+                    <a:a name="ENABLE" value="TRUE"/>
+                  </d:ref>
+                  <d:ctr name="RteComponentTypeCalibration" type="IDENTIFIABLE">
+                    <a:a name="ENABLE" value="false"/>
+                    <d:var name="RteCalibrationSupportEnabled" type="BOOLEAN" 
+                           value="true">
+                      <a:a name="IMPORTER_INFO" value="@DEF"/>
+                    </d:var>
+                    <d:lst name="RteCalibrationSwAddrMethodRef"/>
+                  </d:ctr>
+                </d:ctr>
+                <d:ctr name="RteSwComponentType_1" type="IDENTIFIABLE">
+                  <d:ref name="RteComponentTypeRef" type="REFERENCE" 
+                         value="ASPath:/DemoApplication/SwComponentTypes/SWC_CyclicCounter"/>
+                  <d:ref name="RteImplementationRef" type="REFERENCE" 
+                         value="ASPath:/DemoApplication/SwcImplementations/Impl_SWC_CyclicCounter">
+                    <a:a name="ENABLE" value="TRUE"/>
+                  </d:ref>
+                  <d:ctr name="RteComponentTypeCalibration" type="IDENTIFIABLE">
+                    <a:a name="ENABLE" value="false"/>
+                    <d:var name="RteCalibrationSupportEnabled" type="BOOLEAN" 
+                           value="true">
+                      <a:a name="IMPORTER_INFO" value="@DEF"/>
+                    </d:var>
+                    <d:lst name="RteCalibrationSwAddrMethodRef"/>
+                  </d:ctr>
+                </d:ctr>
+                <d:ctr name="RteSwComponentType_2" type="IDENTIFIABLE">
+                  <d:ref name="RteComponentTypeRef" type="REFERENCE" 
+                         value="ASPath:/DemoApplication/SwComponentTypes/SWC_IoHwAbs"/>
+                  <d:ref name="RteImplementationRef" type="REFERENCE" 
+                         value="ASPath:/DemoApplication/SwcImplementations/Impl_SWC_IoHwAbs">
+                    <a:a name="ENABLE" value="TRUE"/>
+                  </d:ref>
+                  <d:ctr name="RteComponentTypeCalibration" type="IDENTIFIABLE">
+                    <a:a name="ENABLE" value="false"/>
+                    <d:var name="RteCalibrationSupportEnabled" type="BOOLEAN" 
+                           value="true">
+                      <a:a name="IMPORTER_INFO" value="@DEF"/>
+                    </d:var>
+                    <d:lst name="RteCalibrationSwAddrMethodRef"/>
+                  </d:ctr>
+                </d:ctr>
+                <d:ctr name="RteSwComponentType_3" type="IDENTIFIABLE">
+                  <d:ref name="RteComponentTypeRef" type="REFERENCE" 
+                         value="ASPath:/AUTOSAR_Det/SwComponentTypes/DevelopmentErrorTracer"/>
+                  <d:ref name="RteImplementationRef" type="REFERENCE" 
+                         value="ASPath:/AUTOSAR_Det/Implementation">
+                    <a:a name="ENABLE" value="TRUE"/>
+                  </d:ref>
+                  <d:ctr name="RteComponentTypeCalibration" type="IDENTIFIABLE">
+                    <a:a name="ENABLE" value="false"/>
+                    <d:var name="RteCalibrationSupportEnabled" type="BOOLEAN" 
+                           value="true">
+                      <a:a name="IMPORTER_INFO" value="@DEF"/>
+                    </d:var>
+                    <d:lst name="RteCalibrationSwAddrMethodRef"/>
+                  </d:ctr>
+                </d:ctr>
+                <d:ctr name="RteSwComponentType_4" type="IDENTIFIABLE">
+                  <d:ref name="RteComponentTypeRef" type="REFERENCE" 
+                         value="ASPath:/AUTOSAR_BswM/SwComponentTypes/BswM"/>
+                  <d:ref name="RteImplementationRef" type="REFERENCE" 
+                         value="ASPath:/AUTOSAR_BswM/SwcImplementations/BswMImplementation">
+                    <a:a name="ENABLE" value="TRUE"/>
+                  </d:ref>
+                  <d:ctr name="RteComponentTypeCalibration" type="IDENTIFIABLE">
+                    <a:a name="ENABLE" value="false"/>
+                    <d:var name="RteCalibrationSupportEnabled" type="BOOLEAN" 
+                           value="true">
+                      <a:a name="IMPORTER_INFO" value="@DEF"/>
+                    </d:var>
+                    <d:lst name="RteCalibrationSwAddrMethodRef"/>
+                  </d:ctr>
+                </d:ctr>
+                <d:ctr name="RteSwComponentType_5" type="IDENTIFIABLE">
+                  <d:ref name="RteComponentTypeRef" type="REFERENCE" 
+                         value="ASPath:/AUTOSAR_ComM/SwComponentTypes/ComM"/>
+                  <d:ref name="RteImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_ComM/SwcImplementations/SwcImplementation_0">
+                    <a:a name="ENABLE" value="TRUE"/>
+                  </d:ref>
+                  <d:ctr name="RteComponentTypeCalibration" type="IDENTIFIABLE">
+                    <a:a name="ENABLE" value="false"/>
+                    <d:var name="RteCalibrationSupportEnabled" type="BOOLEAN" 
+                           value="true">
+                      <a:a name="IMPORTER_INFO" value="@DEF"/>
+                    </d:var>
+                    <d:lst name="RteCalibrationSwAddrMethodRef"/>
+                  </d:ctr>
+                </d:ctr>
+                <d:ctr name="RteSwComponentType_6" type="IDENTIFIABLE">
+                  <d:ref name="RteComponentTypeRef" type="REFERENCE" 
+                         value="ASPath:/AUTOSAR_NvM/SwComponentTypes/NvM"/>
+                  <d:ref name="RteImplementationRef" type="REFERENCE" 
+                         value="ASPath:/EB_NvM/SwcImplementations/NvMImpl">
+                    <a:a name="ENABLE" value="TRUE"/>
+                  </d:ref>
+                  <d:ctr name="RteComponentTypeCalibration" type="IDENTIFIABLE">
+                    <a:a name="ENABLE" value="false"/>
+                    <d:var name="RteCalibrationSupportEnabled" type="BOOLEAN" 
+                           value="true">
+                      <a:a name="IMPORTER_INFO" value="@DEF"/>
+                    </d:var>
+                    <d:lst name="RteCalibrationSwAddrMethodRef"/>
+                  </d:ctr>
+                </d:ctr>
+              </d:lst>
+            </d:ctr>
+          </d:chc>
+        </d:lst>
+      </d:ctr>
+    </d:lst>
+  </d:ctr>
+
+</datamodel>

--- a/tests/integration/test_xdm_file_parsing.py
+++ b/tests/integration/test_xdm_file_parsing.py
@@ -1,0 +1,96 @@
+"""
+Integration tests for XDM file parsing using real EB Tresos demo files.
+
+Tests that parsers can successfully parse real-world XDM configuration files
+from EB Tresos AutoCore demo projects.
+
+Implements: SWR_INTEGRATION_00001 (XDM file integration tests)
+"""
+import os
+import pytest
+
+from eb_model.parser.core.eb_parser_factory import EbParserFactory
+from eb_model.core.parser_writer_registry import get_module_name
+from eb_model.models import EBModel
+
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), "data_files")
+
+
+# XDM files that successfully parse with current parsers.
+# Note: Other modules (Os, EcuC, NvM, Ea, SoAd, ComM, PduR, Com, CanIf) fail
+# due to schema incompatibilities with EB Tresos demo XDM files.
+# Driver modules (Can, Eth) have no parser implementation.
+XDM_FILES = [
+    ("Rte", "simple_demo_can_rte/config/Rte.xdm"),
+    ("Rte", "simple_demo_eth_rte/config/Rte.xdm"),
+    ("Rte", "simple_demo_mem_can_rte/config/Rte.xdm"),
+    ("MemIf", "simple_demo_mem_can_rte/config/MemIf.xdm"),
+    ("EthIf", "simple_demo_eth_rte/config/EthIf.xdm"),
+]
+
+
+XDM_FILE_IDS = [f"{m}-{p.replace('/', '-')}" for m, p in XDM_FILES]
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("expected_module,xdm_relative_path", XDM_FILES, ids=XDM_FILE_IDS)
+def test_xdm_parsing_pipeline(expected_module, xdm_relative_path):
+    """
+    Test complete XDM parsing pipeline: parser creation, parsing, and model integration.
+
+    Args:
+        expected_module: Expected module name (e.g., "Rte", "MemIf")
+        xdm_relative_path: Relative path to XDM file within data directory
+
+    Implements: SWR_INTEGRATION_00002-00004 (Unified parsing test)
+    """
+    xdm_path = os.path.join(DATA_DIR, xdm_relative_path)
+
+    # Create parser and verify correct module detected
+    parser = EbParserFactory.create(xdm_path)
+    assert parser is not None, f"Failed to create parser for {xdm_path}"
+    module_name = get_module_name(parser.__class__)
+    assert module_name == expected_module, (
+        f"Expected module {expected_module} but got {module_name} for {xdm_relative_path}"
+    )
+
+    # Parse and verify no errors
+    doc = EBModel.getInstance()
+    parser.parse_xdm(xdm_path, doc)
+
+    # Verify module stored in model at standard path
+    module_path = f"/{expected_module}/{expected_module}"
+    module = doc.find(module_path)
+    assert module is not None, (
+        f"Module {expected_module} not found in EBModel after parsing {xdm_relative_path}"
+    )
+
+
+@pytest.mark.integration
+def test_all_selected_modules_are_tested():
+    """
+    Verify that all working module types are covered by the test data.
+
+    Due to schema incompatibilities with EB Tresos demo XDM files,
+    only Rte, MemIf, and EthIf parsers work with these specific files.
+
+    Implements: SWR_INTEGRATION_00005 (Module coverage test)
+    """
+    expected_modules = {"Rte", "MemIf", "EthIf"}
+    actual_modules = {module for module, _ in XDM_FILES}
+    missing_modules = expected_modules - actual_modules
+    assert not missing_modules, f"Missing modules in test data: {missing_modules}"
+
+
+@pytest.mark.integration
+def test_all_xdm_files_exist():
+    """
+    Verify all XDM files referenced in test data actually exist.
+
+    Implements: SWR_INTEGRATION_00006 (Test data validation)
+    """
+    for _, xdm_relative_path in XDM_FILES:
+        xdm_path = os.path.join(DATA_DIR, xdm_relative_path)
+        assert os.path.exists(xdm_path), f"XDM file not found: {xdm_path}"
+        assert os.path.isfile(xdm_path), f"Not a file: {xdm_path}"


### PR DESCRIPTION
## Summary

Add integration tests for XDM file parsing using real EB Tresos demo files to validate parser functionality.

## Changes

- Created  with parameterized tests
- Added test data directory with XDM files from EB Tresos demo projects
- Registered  pytest marker in 

## Test Coverage

The integration tests validate:
- Parser creation for each XDM file
- Successful parsing without errors  
- Module data storage in EBModel singleton

## Files Modified

-  (new)
-  (new - 5 XDM test files)
-  (added integration marker)

## Requirements

Implements: SWR_INTEGRATION_00001 (XDM file integration tests)

## Notes

Currently 5 XDM files are tested:
- Rte.xdm from 3 demo projects (simple_demo_can_rte, simple_demo_eth_rte, simple_demo_mem_can_rte)
- MemIf.xdm from simple_demo_mem_can_rte
- EthIf.xdm from simple_demo_eth_rte

Other modules (Os, EcuC, NvM, Ea, SoAd, ComM, PduR, Com, CanIf) fail due to schema incompatibilities with EB Tresos demo XDM files. Driver modules (Can, Eth) have no parser implementation.

Closes #94