### PR TITLE
feat: v1.3.1 maintenance release - redundancy removal and bug fixes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,7 @@
         "datamodel",
         "ebmodel",
         "Ecuc",
+        "ecum",
         "Impls",
         "infineon",
         "isrs",

--- a/README.md
+++ b/README.md
@@ -195,6 +195,27 @@ pref-system-importer --base-path /path/to/project --ab-project --project MyProje
 
 ## Change History
 
+### Version 1.3.1
+
+**Maintenance Release - Redundancy Removal and Bug Fixes**
+
+1. **Model Simplification**
+   - Removed redundant version fields from `PublishedInformation` (OS and EcuC modules), as these fields are already defined in `CommonPublishedInformation`
+   - Added `PbcfgMSupport` flag to `PublishedInformation` model
+   - Added `getTargetRef()`/`setTargetRef()` convenience methods to `EcucPartitionSoftwareComponentInstanceRef`
+
+2. **Parser Fixes**
+   - Changed `OsEventMask` parsing from `read_value` to `read_optional_value` to handle optional fields correctly
+   - Temporarily disabled non-functional parser methods (`OsSpinlock`, `OsOS`, `OsHooks`) to prevent confusion during export
+   - Fixed `Os.publishedInformation` type from `PublishedInformation` to `CommonPublishedInformation`
+
+3. **Reporter Fixes**
+   - Removed `skip_os_task` guard — OS tasks are now always written regardless of the skip option
+
+4. **CI Improvements**
+   - PyPI publish workflow updated with OIDC authentication
+   - Comprehensive Python `.gitignore` added
+
 ### Version 1.3.0
 
 **Major Release - Complete XDM Model Coverage**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "py_eb_model"
-version = "1.3.0"
+version = "1.3.1"
 license = {text = "MIT"}
 description = "The parser for EB XDM file"
 readme = "README.md"

--- a/src/eb_model/__init__.py
+++ b/src/eb_model/__init__.py
@@ -27,7 +27,7 @@ from eb_model.models import (
     OsScheduleTableEventSetting, OsScheduleTableExpiryPoint, OsScheduleTable,
     MkMemoryRegion, MkMemoryProtection, MkFunction, MkStack,
     MkThreadCustomization, MkOptimization, OsMicrokernel,
-    CommonPublishedInformation, PublishedInformation, OsHwIncrementer,
+    CommonPublishedInformation, OsHwIncrementer,
     OsEvent, OsSpinlock, OsPeripheralArea, OsOS, OsHooks,
     OsCoreConfig, OsAutosarCustomization, Os,
     RteBswGeneral, RteBswEventToIsrMapping, RteBswExclusiveAreaImpl,

--- a/src/eb_model/models/core/ecuc_xdm.py
+++ b/src/eb_model/models/core/ecuc_xdm.py
@@ -15,6 +15,12 @@ class EcucPartitionSoftwareComponentInstanceRef(EcucParamConfContainerDef):
         self.ecucPartitionSoftwareComponentInstanceTargetRef = target
         return self
 
+    def getTargetRef(self) -> EcucRefType:
+        return self.getEcucPartitionSoftwareComponentInstanceTargetRef()
+
+    def setTargetRef(self, target: EcucRefType):
+        return self.setEcucPartitionSoftwareComponentInstanceTargetRef(target)
+
 
 class EcucPartition(EcucParamConfContainerDef):
     def __init__(self, parent, name):
@@ -169,73 +175,18 @@ class CommonPublishedInformation(EcucParamConfContainerDef):
 
 class PublishedInformation(EcucParamConfContainerDef):
     """
-    Module-specific published information.
+    Module-specific published information containing PbcfgMSupport flag.
     """
     def __init__(self, parent, name) -> None:
         super().__init__(parent, name)
+        self.pbcfgMSupport: bool = None
 
-        self.vendorId: str = None
-        self.arReleaseMajorVersion: str = None
-        self.arReleaseMinorVersion: str = None
-        self.arReleasePatchVersion: str = None
-        self.swMajorVersion: str = None
-        self.swMinorVersion: str = None
-        self.swPatchVersion: str = None
+    def getPbcfgMSupport(self) -> bool:
+        return self.pbcfgMSupport
 
-    def getVendorId(self) -> str:
-        return self.vendorId
-
-    def setVendorId(self, value: str):
+    def setPbcfgMSupport(self, value: bool):
         if value is not None:
-            self.vendorId = value
-        return self
-
-    def getArReleaseMajorVersion(self) -> str:
-        return self.arReleaseMajorVersion
-
-    def setArReleaseMajorVersion(self, value: str):
-        if value is not None:
-            self.arReleaseMajorVersion = value
-        return self
-
-    def getArReleaseMinorVersion(self) -> str:
-        return self.arReleaseMinorVersion
-
-    def setArReleaseMinorVersion(self, value: str):
-        if value is not None:
-            self.arReleaseMinorVersion = value
-        return self
-
-    def getArReleasePatchVersion(self) -> str:
-        return self.arReleasePatchVersion
-
-    def setArReleasePatchVersion(self, value: str):
-        if value is not None:
-            self.arReleasePatchVersion = value
-        return self
-
-    def getSwMajorVersion(self) -> str:
-        return self.swMajorVersion
-
-    def setSwMajorVersion(self, value: str):
-        if value is not None:
-            self.swMajorVersion = value
-        return self
-
-    def getSwMinorVersion(self) -> str:
-        return self.swMinorVersion
-
-    def setSwMinorVersion(self, value: str):
-        if value is not None:
-            self.swMinorVersion = value
-        return self
-
-    def getSwPatchVersion(self) -> str:
-        return self.swPatchVersion
-
-    def setSwPatchVersion(self, value: str):
-        if value is not None:
-            self.swPatchVersion = value
+            self.pbcfgMSupport = value
         return self
 
 

--- a/src/eb_model/models/core/os_xdm.py
+++ b/src/eb_model/models/core/os_xdm.py
@@ -1415,75 +1415,20 @@ class CommonPublishedInformation(EcucParamConfContainerDef):
 
 class PublishedInformation(EcucParamConfContainerDef):
     """
-    Module-specific published information.
+    Module-specific published information containing PbcfgMSupport flag.
 
     Implements: SWR_OS_00011 (Module metadata)
     """
     def __init__(self, parent, name) -> None:
         super().__init__(parent, name)
+        self.pbcfgMSupport: bool = None
 
-        self.vendorId: str = None
-        self.arReleaseMajorVersion: str = None
-        self.arReleaseMinorVersion: str = None
-        self.arReleasePatchVersion: str = None
-        self.swMajorVersion: str = None
-        self.swMinorVersion: str = None
-        self.swPatchVersion: str = None
+    def getPbcfgMSupport(self) -> bool:
+        return self.pbcfgMSupport
 
-    def getVendorId(self) -> str:
-        return self.vendorId
-
-    def setVendorId(self, value: str):
+    def setPbcfgMSupport(self, value: bool):
         if value is not None:
-            self.vendorId = value
-        return self
-
-    def getArReleaseMajorVersion(self) -> str:
-        return self.arReleaseMajorVersion
-
-    def setArReleaseMajorVersion(self, value: str):
-        if value is not None:
-            self.arReleaseMajorVersion = value
-        return self
-
-    def getArReleaseMinorVersion(self) -> str:
-        return self.arReleaseMinorVersion
-
-    def setArReleaseMinorVersion(self, value: str):
-        if value is not None:
-            self.arReleaseMinorVersion = value
-        return self
-
-    def getArReleasePatchVersion(self) -> str:
-        return self.arReleasePatchVersion
-
-    def setArReleasePatchVersion(self, value: str):
-        if value is not None:
-            self.arReleasePatchVersion = value
-        return self
-
-    def getSwMajorVersion(self) -> str:
-        return self.swMajorVersion
-
-    def setSwMajorVersion(self, value: str):
-        if value is not None:
-            self.swMajorVersion = value
-        return self
-
-    def getSwMinorVersion(self) -> str:
-        return self.swMinorVersion
-
-    def setSwMinorVersion(self, value: str):
-        if value is not None:
-            self.swMinorVersion = value
-        return self
-
-    def getSwPatchVersion(self) -> str:
-        return self.swPatchVersion
-
-    def setSwPatchVersion(self, value: str):
-        if value is not None:
-            self.swPatchVersion = value
+            self.pbcfgMSupport = value
         return self
 
 
@@ -1822,7 +1767,7 @@ class Os(Module):
         self.osResources: List[OsResource] = []
         self.osMicrokernel: OsMicrokernel = None
         self.commonPublishedInformation: CommonPublishedInformation = None
-        self.publishedInformation: PublishedInformation = None
+        self.publishedInformation: CommonPublishedInformation = None
         self.osHwIncrementer: OsHwIncrementer = None
         self.osEvents: List[OsEvent] = []
         self.osSpinlocks: List[OsSpinlock] = []
@@ -1931,10 +1876,10 @@ class Os(Module):
             self.commonPublishedInformation = value
         return self
 
-    def getPublishedInformation(self) -> PublishedInformation:
+    def getPublishedInformation(self) -> CommonPublishedInformation:
         return self.publishedInformation
 
-    def setPublishedInformation(self, value: PublishedInformation):
+    def setPublishedInformation(self, value: CommonPublishedInformation):
         if value is not None:
             self.publishedInformation = value
         return self

--- a/src/eb_model/parser/core/ecuc_xdm_parser.py
+++ b/src/eb_model/parser/core/ecuc_xdm_parser.py
@@ -57,13 +57,7 @@ class EcucXdmParser(AbstractEbModelParser):
         ctr_tag = self.find_ctr_tag(element, "PublishedInformation")
         if ctr_tag is not None:
             pub_info = PublishedInformation(ecuc, ctr_tag.attrib["name"])
-            pub_info.setVendorId(self.read_value(ctr_tag, "VendorId"))
-            pub_info.setArReleaseMajorVersion(self.read_value(ctr_tag, "ArReleaseMajorVersion"))
-            pub_info.setArReleaseMinorVersion(self.read_value(ctr_tag, "ArReleaseMinorVersion"))
-            pub_info.setArReleasePatchVersion(self.read_value(ctr_tag, "ArReleasePatchVersion"))
-            pub_info.setSwMajorVersion(self.read_value(ctr_tag, "SwMajorVersion"))
-            pub_info.setSwMinorVersion(self.read_value(ctr_tag, "SwMinorVersion"))
-            pub_info.setSwPatchVersion(self.read_value(ctr_tag, "SwPatchVersion"))
+            pub_info.setPbcfgMSupport(self.read_value(ctr_tag, "PbcfgMSupport"))
             ecuc.setPublishedInformation(pub_info)
             self.logger.debug("Read PublishedInformation")
 

--- a/src/eb_model/parser/core/os_xdm_parser.py
+++ b/src/eb_model/parser/core/os_xdm_parser.py
@@ -69,13 +69,12 @@ class OsXdmParser(AbstractEbModelParser):
         self.read_os_resources(element, os)
         self.read_os_microkernel(element, os)
         self.read_common_published_information(element, os)
-        self.read_published_information(element, os)
         self.read_os_hw_incrementer(element, os)
         self.read_os_events(element, os)
-        self.read_os_spinlocks(element, os)
+        # self.read_os_spinlocks(element, os)
         self.read_os_peripheral_areas(element, os)
-        self.read_os_os(element, os)
-        self.read_os_hooks(element, os)
+        # self.read_os_os(element, os)
+        # self.read_os_hooks(element, os)
         self.read_os_core_configs(element, os)
         self.read_os_autosar_customization(element, os)
 
@@ -373,13 +372,7 @@ class OsXdmParser(AbstractEbModelParser):
         ctr_tag = self.find_ctr_tag(element, "PublishedInformation")
         if ctr_tag is not None:
             pub_info = PublishedInformation(os, ctr_tag.attrib["name"])
-            pub_info.setVendorId(self.read_value(ctr_tag, "VendorId"))
-            pub_info.setArReleaseMajorVersion(self.read_value(ctr_tag, "ArReleaseMajorVersion"))
-            pub_info.setArReleaseMinorVersion(self.read_value(ctr_tag, "ArReleaseMinorVersion"))
-            pub_info.setArReleasePatchVersion(self.read_value(ctr_tag, "ArReleasePatchVersion"))
-            pub_info.setSwMajorVersion(self.read_value(ctr_tag, "SwMajorVersion"))
-            pub_info.setSwMinorVersion(self.read_value(ctr_tag, "SwMinorVersion"))
-            pub_info.setSwPatchVersion(self.read_value(ctr_tag, "SwPatchVersion"))
+            pub_info.setPbcfgMSupport(self.read_value(ctr_tag, "PbcfgMSupport"))
             os.setPublishedInformation(pub_info)
             self.logger.debug("Read PublishedInformation")
 
@@ -397,7 +390,7 @@ class OsXdmParser(AbstractEbModelParser):
         """Parse all OsEvent containers from XDM."""
         for ctr_tag in self.find_ctr_tag_list(element, "OsEvent"):
             event = OsEvent(os, ctr_tag.attrib["name"])
-            event.setOsEventMask(self.read_value(ctr_tag, "OsEventMask"))
+            event.setOsEventMask(self.read_optional_value(ctr_tag, "OsEventMask"))
             os.addOsEvent(event)
             self.logger.debug("Read OsEvent <%s>" % event.getName())
 

--- a/src/eb_model/reporter/excel_reporter/core/os_xdm.py
+++ b/src/eb_model/reporter/excel_reporter/core/os_xdm.py
@@ -218,8 +218,8 @@ class OsXdmXlsWriter(ExcelReporter):
     def write(self, filename, doc: EBModel, options={"skip_os_task": False}):
         self.logger.info("Writing <%s>" % filename)
 
-        if not options['skip_os_task']:
-            self.write_os_tasks(doc)
+        # if not options['skip_os_task']:
+        self.write_os_tasks(doc)
         self.write_os_applications(doc)
         self.write_os_isrs(doc)
         self.write_os_schedule_tables(doc)

--- a/tests/models/core/test_ecuc_xdm.py
+++ b/tests/models/core/test_ecuc_xdm.py
@@ -94,24 +94,14 @@ class TestPublishedInformation:
 
         assert pub_info.getName() == "PublishedInformation"
         assert pub_info.getParent() == root
-        assert pub_info.getVendorId() is None
-        assert pub_info.getArReleaseMajorVersion() is None
-        assert pub_info.getArReleaseMinorVersion() is None
-        assert pub_info.getArReleasePatchVersion() is None
+        assert pub_info.getPbcfgMSupport() is None
 
-    def test_set_vendor_id(self):
+    def test_set_pbcfg_m_support(self):
         root = EBModel.getInstance()
         pub_info = PublishedInformation(root, "PublishedInformation")
 
-        assert pub_info.setVendorId("Vector") == pub_info
-        assert pub_info.getVendorId() == "Vector"
-
-    def test_set_ar_release_major_version(self):
-        root = EBModel.getInstance()
-        pub_info = PublishedInformation(root, "PublishedInformation")
-
-        assert pub_info.setArReleaseMajorVersion("4") == pub_info
-        assert pub_info.getArReleaseMajorVersion() == "4"
+        assert pub_info.setPbcfgMSupport(False) == pub_info
+        assert pub_info.getPbcfgMSupport() is False
 
 
 class TestEcucGeneral:

--- a/tests/parser/core/test_ecuc_xdm_parser.py
+++ b/tests/parser/core/test_ecuc_xdm_parser.py
@@ -61,13 +61,7 @@ class TestEcucXdmParser:
                 xmlns:v="http://www.tresos.de/_projects/DataModel2/06/schema.xsd"
                 xmlns:d="http://www.tresos.de/_projects/DataModel2/06/data.xsd">
             <d:ctr name="PublishedInformation" type="IDENTIFIABLE">
-                <d:var name="VendorId" type="STRING" value="Vector"/>
-                <d:var name="ArReleaseMajorVersion" type="STRING" value="4"/>
-                <d:var name="ArReleaseMinorVersion" type="STRING" value="3"/>
-                <d:var name="ArReleasePatchVersion" type="STRING" value="0"/>
-                <d:var name="SwMajorVersion" type="STRING" value="1"/>
-                <d:var name="SwMinorVersion" type="STRING" value="0"/>
-                <d:var name="SwPatchVersion" type="STRING" value="0"/>
+                <d:var name="PbcfgMSupport" type="BOOLEAN" value="false"/>
             </d:ctr>
         </datamodel>
         """
@@ -80,10 +74,7 @@ class TestEcucXdmParser:
 
         pub_info = ecuc.getPublishedInformation()
         assert pub_info is not None
-        assert pub_info.getVendorId() == "Vector"
-        assert pub_info.getArReleaseMajorVersion() == "4"
-        assert pub_info.getArReleaseMinorVersion() == "3"
-        assert pub_info.getArReleasePatchVersion() == "0"
+        assert pub_info.getPbcfgMSupport() is False
 
     def test_read_ecuc_general(self):
         xml_content = """

--- a/tests/parser/core/test_os_new_containers.py
+++ b/tests/parser/core/test_os_new_containers.py
@@ -64,13 +64,7 @@ class TestOsPublishedInformation:
                 xmlns:v="http://www.tresos.de/_projects/DataModel2/06/schema.xsd"
                 xmlns:d="http://www.tresos.de/_projects/DataModel2/06/data.xsd">
             <d:ctr name="PublishedInformation">
-                <d:var name="VendorId" type="STRING" value="EB"/>
-                <d:var name="ArReleaseMajorVersion" type="STRING" value="4"/>
-                <d:var name="ArReleaseMinorVersion" type="STRING" value="2"/>
-                <d:var name="ArReleasePatchVersion" type="STRING" value="0"/>
-                <d:var name="SwMajorVersion" type="STRING" value="1"/>
-                <d:var name="SwMinorVersion" type="STRING" value="2"/>
-                <d:var name="SwPatchVersion" type="STRING" value="3"/>
+                <d:var name="PbcfgMSupport" type="BOOLEAN" value="false"/>
             </d:ctr>
         </datamodel>
         """
@@ -89,13 +83,7 @@ class TestOsPublishedInformation:
 
         pub_info = os.getPublishedInformation()
         assert pub_info is not None
-        assert pub_info.getVendorId() == "EB"
-        assert pub_info.getArReleaseMajorVersion() == "4"
-        assert pub_info.getArReleaseMinorVersion() == "2"
-        assert pub_info.getArReleasePatchVersion() == "0"
-        assert pub_info.getSwMajorVersion() == "1"
-        assert pub_info.getSwMinorVersion() == "2"
-        assert pub_info.getSwPatchVersion() == "3"
+        assert pub_info.getPbcfgMSupport() is False
 
 
 class TestOsHwIncrementer:
@@ -346,8 +334,6 @@ class TestOsCoreConfig:
         assert core_configs[1].getName() == "Core1"
         assert core_configs[1].getOsCoreId() == 1
         assert core_configs[1].getOsCoreMainFunction() == "Main_Core1"
-        assert core_configs[1].getOsCoreStackStartAddress() == 536875008
-        assert core_configs[1].getOsCoreStackSize() == 4096
         assert core_configs[1].getOsCoreStackStartAddress() == 536875008
         assert core_configs[1].getOsCoreStackSize() == 4096
 


### PR DESCRIPTION
## Summary

- **Model Simplification**: Removed redundant version fields from `PublishedInformation`, added `PbcfgMSupport` flag, added `getTargetRef()`/`setTargetRef()` convenience methods
- **Parser Fixes**: Fixed `OsEventMask` optional handling, disabled non-functional parsers, fixed type annotation
- **Reporter Fixes**: Removed broken `skip_os_task` guard
- **CI Improvements**: OIDC-based PyPI publish workflow, updated .gitignore

## Test Plan

- [x] Ruff lint: all checks passed
- [x] Unit tests: 465 passed, 0 failed

Closes #105