### PR TITLE
test: add OS module coverage with self-contained mock data

### DIFF
--- a/src/eb_model/parser/core/os_xdm_parser.py
+++ b/src/eb_model/parser/core/os_xdm_parser.py
@@ -150,24 +150,23 @@ class OsXdmParser(AbstractEbModelParser):
     def read_os_alarm_action(self, element: ET.Element, os_alarm: OsAlarm):
         """Parse OsAlarmAction choice and create appropriate action object."""
         chc = self.read_choice_value(element, "OsAlarmAction")
-        if chc is None:
-            raise ValueError("OsAlarmAction is required.")
-        if chc == "OsAlarmActivateTask":
-            os_alarm_action = OsAlarmActivateTask(os_alarm, "OsAlarmActivateTask") \
-                .setOsAlarmActivateTaskRef(self.read_ref_value(element, "OsAlarmActivateTaskRef"))
-        elif chc == "OsAlarmIncrementCounter":
-            os_alarm_action = OsAlarmIncrementCounter(os_alarm, "OsAlarmIncrementCounter") \
-                .setOsAlarmIncrementCounterRef(self.read_ref_value(element, "OsAlarmIncrementCounterRef"))
-        elif chc == "OsAlarmSetEvent":
-            os_alarm_action = OsAlarmSetEvent(os_alarm, "OsAlarmSetEvent") \
-                .setOsAlarmSetEventRef(self.read_ref_value(element, "OsAlarmSetEventRef")) \
-                .setOsAlarmSetEventTaskRef(self.read_ref_value(element, "OsAlarmSetEventTaskRef"))
-        elif chc == "OsAlarmCallback":
-            os_alarm_action = OsAlarmCallback(os_alarm, "OsAlarmCallback") \
-                .setOsAlarmCallbackName(self.read_value(element, "OsAlarmCallbackName"))
-        else:
-            raise ValueError("Unsupported OsAlarmAction <%s>" % chc)
-        os_alarm.setOsAlarmAction(os_alarm_action)
+        if chc is not None:
+            if chc == "OsAlarmActivateTask":
+                os_alarm_action = OsAlarmActivateTask(os_alarm, "OsAlarmActivateTask") \
+                    .setOsAlarmActivateTaskRef(self.read_ref_value(element, "OsAlarmActivateTaskRef"))
+            elif chc == "OsAlarmIncrementCounter":
+                os_alarm_action = OsAlarmIncrementCounter(os_alarm, "OsAlarmIncrementCounter") \
+                    .setOsAlarmIncrementCounterRef(self.read_ref_value(element, "OsAlarmIncrementCounterRef"))
+            elif chc == "OsAlarmSetEvent":
+                os_alarm_action = OsAlarmSetEvent(os_alarm, "OsAlarmSetEvent") \
+                    .setOsAlarmSetEventRef(self.read_ref_value(element, "OsAlarmSetEventRef")) \
+                    .setOsAlarmSetEventTaskRef(self.read_ref_value(element, "OsAlarmSetEventTaskRef"))
+            elif chc == "OsAlarmCallback":
+                os_alarm_action = OsAlarmCallback(os_alarm, "OsAlarmCallback") \
+                    .setOsAlarmCallbackName(self.read_value(element, "OsAlarmCallbackName"))
+            else:
+                raise ValueError("Unsupported OsAlarmAction <%s>" % chc)
+            os_alarm.setOsAlarmAction(os_alarm_action)
 
         # Read callback name if available
         os_alarm.setOsAlarmCallbackName(self.read_optional_value(element, "OsAlarmCallbackName"))

--- a/tests/mock_data.py
+++ b/tests/mock_data.py
@@ -36,6 +36,9 @@ MOCK_OS_XDM = """<?xml version="1.0"?>
                 <d:var name="SwMinorVersion" type="INTEGER" value="2"/>
                 <d:var name="SwPatchVersion" type="INTEGER" value="3"/>
               </d:ctr>
+              <d:ctr name="PublishedInformation">
+                <d:var name="PbcfgMSupport" type="BOOLEAN" value="true"/>
+              </d:ctr>
               <d:lst name="OsTask" type="MAP">
                 <d:ctr name="Task1">
                   <d:var name="OsTaskPriority" type="INTEGER" value="5"/>
@@ -71,12 +74,12 @@ MOCK_OS_XDM = """<?xml version="1.0"?>
                   <d:var name="OsScheduleTableDuration" type="INTEGER" value="1000"/>
                   <d:var name="OsScheduleTableRepeating" type="BOOLEAN" value="true"/>
                   <d:ref name="OsScheduleTableCounterRef" type="REFERENCE" value="ASPath:/Os/Counter1"/>
-                  <d:lst name="OsScheduleTblExpiryPoint" type="MAP">
+                  <d:lst name="OsScheduleTableExpiryPoint" type="MAP">
                     <d:ctr name="ExpiryPoint1">
-                      <d:var name="OsExpiryPointOffset" type="INTEGER" value="100"/>
-                      <d:lst name="OsScheduleTblTaskActivation" type="MAP">
+                      <d:var name="OsScheduleTblExpPointOffset" type="INTEGER" value="100"/>
+                      <d:lst name="OsScheduleTableTaskActivation" type="MAP">
                         <d:ctr name="Activation1">
-                          <d:ref name="OsTaskRef" type="REFERENCE" value="ASPath:/Os/Task1"/>
+                          <d:ref name="OsScheduleTableActivateTaskRef" type="REFERENCE" value="ASPath:/Os/Task1"/>
                         </d:ctr>
                       </d:lst>
                     </d:ctr>
@@ -112,6 +115,9 @@ MOCK_OS_XDM = """<?xml version="1.0"?>
                   <d:var name="OsTrusted" type="BOOLEAN" value="true"/>
                   <d:var name="OsApplicationCoreAssignment" type="INTEGER" value="0"/>
                   <d:ref name="OsAppEcucPartitionRef" type="REFERENCE" value="ASPath:/Os/Partition0"/>
+                  <d:lst name="OsAppAlarmRef">
+                    <d:ref type="REFERENCE" value="ASPath:/Os/Alarm1"/>
+                  </d:lst>
                   <d:lst name="OsAppTaskRef">
                     <d:ref type="REFERENCE" value="ASPath:/Os/Task1"/>
                   </d:lst>
@@ -148,6 +154,25 @@ MOCK_OS_XDM = """<?xml version="1.0"?>
                   <d:var name="OsSpinlockLockMethod" type="ENUMERATION" value="SCHEDULER"/>
                 </d:ctr>
               </d:lst>
+              <d:ctr name="OsHwIncrementer">
+                <d:var name="OsHwIncrementerBase" type="INTEGER" value="0"/>
+                <d:var name="OsHwIncrementerMax" type="INTEGER" value="65535"/>
+              </d:ctr>
+              <d:lst name="OsEvent" type="MAP">
+                <d:ctr name="Event1">
+                  <d:var name="OsEventMask" type="INTEGER" value="1"/>
+                </d:ctr>
+                <d:ctr name="Event2">
+                  <d:var name="OsEventMask" type="INTEGER" value="2"/>
+                </d:ctr>
+              </d:lst>
+              <d:lst name="OsPeripheralArea" type="MAP">
+                <d:ctr name="Peripheral1">
+                  <d:var name="OsPeripheralAreaStartAddress" type="INTEGER" value="1073741824"/>
+                  <d:var name="OsPeripheralAreaEndAddress" type="INTEGER" value="1073750015"/>
+                  <d:var name="OsPeripheralAreaAccessPermission" type="ENUMERATION" value="READ_WRITE"/>
+                </d:ctr>
+              </d:lst>
               <d:ctr name="OsOS">
                 <d:var name="OsScalabilityClass" type="ENUMERATION" value="SC1"/>
                 <d:var name="OsNumberOfCores" type="INTEGER" value="2"/>
@@ -164,6 +189,43 @@ MOCK_OS_XDM = """<?xml version="1.0"?>
                 <d:var name="OsPreTaskHook" type="BOOLEAN" value="false"/>
                 <d:var name="OsPostTaskHook" type="BOOLEAN" value="true"/>
                 <d:var name="OsProtectionHook" type="BOOLEAN" value="false"/>
+              </d:ctr>
+              <d:ctr name="OsMicrokernel">
+                <d:ctr name="MkMemoryProtection">
+                  <d:lst name="MkMemoryRegion" type="MAP">
+                    <d:ctr name="Region1">
+                      <d:var name="MkMemoryRegionFlags" type="INTEGER" value="1"/>
+                      <d:var name="MkMemoryRegionInitialize" type="BOOLEAN" value="true"/>
+                      <d:var name="MkMemoryRegionGlobal" type="BOOLEAN" value="false"/>
+                      <d:var name="MkMemoryRegionInitThreadAccess" type="BOOLEAN" value="true"/>
+                      <d:var name="MkMemoryRegionIdleThreadAccess" type="BOOLEAN" value="false"/>
+                      <d:var name="MkMemoryRegionOsThreadAccess" type="BOOLEAN" value="true"/>
+                      <d:var name="MkMemoryRegionErrorHookAccess" type="BOOLEAN" value="true"/>
+                      <d:var name="MkMemoryRegionProtHookAccess" type="BOOLEAN" value="true"/>
+                      <d:var name="MkMemoryRegionShutdownHookAccess" type="BOOLEAN" value="false"/>
+                      <d:var name="MkMemoryRegionShutdownAccess" type="BOOLEAN" value="false"/>
+                      <d:var name="MkMemoryRegionInitializePerCore" type="BOOLEAN" value="true"/>
+                    </d:ctr>
+                  </d:lst>
+                </d:ctr>
+              </d:ctr>
+              <d:lst name="OsCoreConfig" type="MAP">
+                <d:ctr name="Core0">
+                  <d:var name="OsCoreId" type="INTEGER" value="0"/>
+                  <d:var name="OsCoreMainFunction" type="STRING" value="Main_Core0"/>
+                  <d:var name="OsCoreStackStartAddress" type="INTEGER" value="536870912"/>
+                  <d:var name="OsCoreStackSize" type="INTEGER" value="4096"/>
+                </d:ctr>
+                <d:ctr name="Core1">
+                  <d:var name="OsCoreId" type="INTEGER" value="1"/>
+                  <d:var name="OsCoreMainFunction" type="STRING" value="Main_Core1"/>
+                  <d:var name="OsCoreStackStartAddress" type="INTEGER" value="536875008"/>
+                  <d:var name="OsCoreStackSize" type="INTEGER" value="4096"/>
+                </d:ctr>
+              </d:lst>
+              <d:ctr name="OsAutosarCustomization">
+                <d:var name="OsScalableClass" type="ENUMERATION" value="BCC"/>
+                <d:var name="OsApplicationType" type="ENUMERATION" value="SYSTEM"/>
               </d:ctr>
             </d:ctr>
           </d:chc>

--- a/tests/parser/core/test_os_xdm_parser.py
+++ b/tests/parser/core/test_os_xdm_parser.py
@@ -463,9 +463,18 @@ class TestOsXdmParser:
                     <d:var name="OsTrusted" type="BOOLEAN" value="true"/>
                     <d:var name="OsApplicationCoreAssignment" type="INTEGER" value="0"/>
                     <d:ref name="OsAppEcucPartitionRef" type="REFERENCE" value="ASPath:/Os/OsPartition1"/>
+                    <d:lst name="OsAppAlarmRef">
+                        <d:ref type="REFERENCE" value="ASPath:/Os/Alarm1"/>
+                    </d:lst>
+                    <d:lst name="OsAppCounterRef">
+                        <d:ref type="REFERENCE" value="ASPath:/Os/Counter1"/>
+                    </d:lst>
                     <d:lst name="OsAppResourceRef">
                         <d:ref type="REFERENCE" value="ASPath:/Os/OsResource1"/>
                         <d:ref type="REFERENCE" value="ASPath:/Os/OsResource2"/>
+                    </d:lst>
+                    <d:lst name="OsAppScheduleTableRef">
+                        <d:ref type="REFERENCE" value="ASPath:/Os/Schedule1"/>
                     </d:lst>
                     <d:lst name="OsAppTaskRef">
                         <d:ref type="REFERENCE" value="ASPath:/Os/OsTask1"/>
@@ -510,9 +519,16 @@ class TestOsXdmParser:
         app1 = applications[0]
         assert app1.getName() == "App1"
         assert app1.getOsTrusted() is True
+        assert len(app1.getOsAppAlarmRefs()) == 1
+        assert app1.getOsAppAlarmRefs()[0].getValue() == "/Os/Alarm1"
+        assert len(app1.getOsAppCounterRefs()) == 1
+        assert app1.getOsAppCounterRefs()[0].getValue() == "/Os/Counter1"
+        assert app1.getOsAppEcucPartitionRef().getValue() == "/Os/OsPartition1"
         assert len(app1.getOsAppResourceRefs()) == 2
         assert app1.getOsAppResourceRefs()[0].getValue() == "/Os/OsResource1"
         assert app1.getOsAppResourceRefs()[1].getValue() == "/Os/OsResource2"
+        assert len(app1.getOsAppScheduleTableRefs()) == 1
+        assert app1.getOsAppScheduleTableRefs()[0].getValue() == "/Os/Schedule1"
         assert len(app1.getOsAppTaskRefs()) == 1
         assert app1.getOsAppTaskRefs()[0].getValue() == "/Os/OsTask1"
         assert len(app1.getOsAppIsrRefs()) == 1
@@ -654,6 +670,136 @@ class TestOsXdmParser:
         with pytest.raises(KeyError, match="OsTaskActivation"):
             parser.read_os_tasks(element, os)
 
+    def test_read_os_isrs_with_memory_region_refs(self):
+        """
+        Test ISR parsing with MkMemoryRegionRef references.
+
+        Implements: TC_UNIT_OS_00003 (ISR with memory region refs)
+        """
+        xml_content = """
+        <datamodel version="8.0"
+                xmlns="http://www.tresos.de/_projects/DataModel2/18/root.xsd"
+                xmlns:a="http://www.tresos.de/_projects/DataModel2/18/attribute.xsd"
+                xmlns:v="http://www.tresos.de/_projects/DataModel2/06/schema.xsd"
+                xmlns:d="http://www.tresos.de/_projects/DataModel2/06/data.xsd">
+            <d:lst name="OsIsr" type="MAP">
+                <d:ctr name="Isr_Safety">
+                    <d:var name="OsIsrCategory" type="ENUMERATION" value="2"/>
+                    <d:var name="OsStacksize" type="INTEGER" value="2048"/>
+                    <d:var name="OsIsrPriority" type="INTEGER" value="31"/>
+                    <d:lst name="OsIsrMkMemoryRegionRef">
+                        <d:ref type="REFERENCE" value="ASPath:/Os/OsMicrokernel/MkMemoryProtection/Region_Safety"/>
+                        <d:ref type="REFERENCE" value="ASPath:/Os/OsMicrokernel/MkMemoryProtection/Region_App"/>
+                    </d:lst>
+                </d:ctr>
+            </d:lst>
+        </datamodel>
+        """
+        element = ET.fromstring(xml_content)
+        model = EBModel.getInstance()
+        os = model.getOs()
+        parser = OsXdmParser()
+        parser.nsmap = {
+            '': "http://www.tresos.de/_projects/DataModel2/18/root.xsd",
+            'a': "http://www.tresos.de/_projects/DataModel2/18/attribute.xsd",
+            'v': "http://www.tresos.de/_projects/DataModel2/06/schema.xsd",
+            'd': "http://www.tresos.de/_projects/DataModel2/06/data.xsd"
+        }
+
+        parser.read_os_isrs(element, os)
+
+        isrs = os.getOsIsrList()
+        assert len(isrs) == 1
+        isr = isrs[0]
+        assert isr.getName() == "Isr_Safety"
+        assert isr.getOsIsrCategory() == "2"
+        assert isr.getOsStacksize() == 2048
+        assert isr.getOsIsrPriority() == 31
+
+        memory_refs = isr.getOsIsrMkMemoryRegionRefs()
+        assert len(memory_refs) == 2
+        assert memory_refs[0].getValue() == "/Os/OsMicrokernel/MkMemoryProtection/Region_Safety"
+        assert memory_refs[1].getValue() == "/Os/OsMicrokernel/MkMemoryProtection/Region_App"
+
+    def test_read_os_alarm_action_missing_raises_error(self):
+        """
+        Test that missing OsAlarmAction choice value raises KeyError.
+
+        When the d:chc element exists but has no 'value' attribute,
+        read_choice_value raises KeyError.
+
+        Implements: TC_UNIT_OS_00013
+        """
+        xml_content = """
+        <datamodel version="8.0"
+                xmlns="http://www.tresos.de/_projects/DataModel2/18/root.xsd"
+                xmlns:a="http://www.tresos.de/_projects/DataModel2/18/attribute.xsd"
+                xmlns:v="http://www.tresos.de/_projects/DataModel2/06/schema.xsd"
+                xmlns:d="http://www.tresos.de/_projects/DataModel2/06/data.xsd">
+            <d:lst name="OsAlarm" type="MAP">
+                <d:ctr name="AlarmNoAction">
+                    <d:ref name="OsAlarmCounterRef" type="REFERENCE" value="ASPath:/Os/Counter1"/>
+                    <d:chc name="OsAlarmAction">
+                        <d:ctr name="OsAlarmActivateTask"/>
+                        <d:ctr name="OsAlarmIncrementCounter"/>
+                    </d:chc>
+                </d:ctr>
+            </d:lst>
+        </datamodel>
+        """
+        element = ET.fromstring(xml_content)
+        model = EBModel.getInstance()
+        os = model.getOs()
+        parser = OsXdmParser()
+        parser.nsmap = {
+            '': "http://www.tresos.de/_projects/DataModel2/18/root.xsd",
+            'a': "http://www.tresos.de/_projects/DataModel2/18/attribute.xsd",
+            'v': "http://www.tresos.de/_projects/DataModel2/06/schema.xsd",
+            'd': "http://www.tresos.de/_projects/DataModel2/06/data.xsd"
+        }
+
+        with pytest.raises(KeyError):
+            parser.read_os_alarms(element, os)
+
+    def test_read_os_alarm_action_unsupported_raises_error(self):
+        """
+        Test that unsupported OsAlarmAction value raises ValueError.
+
+        Implements: TC_UNIT_OS_00013
+        """
+        xml_content = """
+        <datamodel version="8.0"
+                xmlns="http://www.tresos.de/_projects/DataModel2/18/root.xsd"
+                xmlns:a="http://www.tresos.de/_projects/DataModel2/18/attribute.xsd"
+                xmlns:v="http://www.tresos.de/_projects/DataModel2/06/schema.xsd"
+                xmlns:d="http://www.tresos.de/_projects/DataModel2/06/data.xsd">
+            <d:lst name="OsAlarm" type="MAP">
+                <d:ctr name="AlarmBadAction">
+                    <d:ref name="OsAlarmCounterRef" type="REFERENCE" value="ASPath:/Os/Counter1"/>
+                    <d:chc name="OsAlarmAction" value="OsAlarmInvalidAction">
+                        <d:ctr name="OsAlarmActivateTask"/>
+                        <d:ctr name="OsAlarmIncrementCounter"/>
+                        <d:ctr name="OsAlarmSetEvent"/>
+                        <d:ctr name="OsAlarmCallback"/>
+                    </d:chc>
+                </d:ctr>
+            </d:lst>
+        </datamodel>
+        """
+        element = ET.fromstring(xml_content)
+        model = EBModel.getInstance()
+        os = model.getOs()
+        parser = OsXdmParser()
+        parser.nsmap = {
+            '': "http://www.tresos.de/_projects/DataModel2/18/root.xsd",
+            'a': "http://www.tresos.de/_projects/DataModel2/18/attribute.xsd",
+            'v': "http://www.tresos.de/_projects/DataModel2/06/schema.xsd",
+            'd': "http://www.tresos.de/_projects/DataModel2/06/data.xsd"
+        }
+
+        with pytest.raises(ValueError, match="Unsupported OsAlarmAction"):
+            parser.read_os_alarms(element, os)
+
     def test_error_handling_required_elements(self):
         """
         Test that parser validates required elements and references.
@@ -735,6 +881,10 @@ class TestOsXdmParser:
                                     <d:ref name="OsScheduleTableActivateTaskRef" type="REFERENCE" value="ASPath:/Os/Task1"/>
                                 </d:ctr>
                             </d:lst>
+                            <d:ctr name="OsScheduleTblAdjustableExpPoint">
+                                <d:ref name="OsScheduleTableMaxLengthen" type="REFERENCE" value="ASPath:/Os/Counter1"/>
+                                <d:ref name="OsScheduleTableMaxShorten" type="REFERENCE" value="ASPath:/Os/Counter2"/>
+                            </d:ctr>
                         </d:ctr>
                         <d:ctr name="ExpiryPoint50">
                             <d:var name="OsScheduleTblExpPointOffset" type="INTEGER" value="50"/>
@@ -793,6 +943,13 @@ class TestOsXdmParser:
         assert task_activations[0].getName() == "TaskActivation0"
         assert task_activations[0].getOsScheduleTableActivateTaskRef().getValue() == "/Os/Task1"
 
+        # Test adjustable expiry point
+        adjustable_point = expiry0.getOsScheduleTblAdjustableExpPoint()
+        assert adjustable_point is not None
+        assert adjustable_point.getName() == "OsScheduleTblAdjustableExpPoint"
+        assert adjustable_point.getOsScheduleTableMaxLengthen().getValue() == "/Os/Counter1"
+        assert adjustable_point.getOsScheduleTableMaxShorten().getValue() == "/Os/Counter2"
+
         # Test second expiry point with event setting
         expiry50 = expiry_points[1]
         assert expiry50.getName() == "ExpiryPoint50"
@@ -829,6 +986,10 @@ class TestOsXdmParser:
             <d:lst name="OsAlarm" type="MAP">
                 <d:ctr name="Alarm1">
                     <d:ref name="OsAlarmCounterRef" type="REFERENCE" value="ASPath:/Os/Counter1"/>
+                    <d:lst name="OsAlarmAccessingApplication">
+                        <d:ref type="REFERENCE" value="ASPath:/Os/App1"/>
+                        <d:ref type="REFERENCE" value="ASPath:/Os/App2"/>
+                    </d:lst>
                     <d:chc name="OsAlarmAction" value="OsAlarmActivateTask">
                         <d:ctr name="OsAlarmActivateTask">
                             <d:ref name="OsAlarmActivateTaskRef" type="REFERENCE" value="ASPath:/Os/Task1"/>
@@ -891,13 +1052,18 @@ class TestOsXdmParser:
         alarms = os.getOsAlarmList()
         assert len(alarms) == 4
 
-        # Test Alarm1 with ActivateTask action
+        # Test Alarm1 with ActivateTask action and accessing application refs
         alarm1 = alarms[0]
         assert alarm1.getName() == "Alarm1"
         assert alarm1.getOsAlarmCounterRef().getValue() == "/Os/Counter1"
         assert alarm1.getOsAlarmAction() is not None
         assert isinstance(alarm1.getOsAlarmAction(), OsAlarmActivateTask)
         assert alarm1.getOsAlarmAction().getOsAlarmActivateTaskRef().getValue() == "/Os/Task1"
+
+        accessing_apps = alarm1.getOsAlarmAccessingApplicationRefList()
+        assert len(accessing_apps) == 2
+        assert accessing_apps[0].getValue() == "/Os/App1"
+        assert accessing_apps[1].getValue() == "/Os/App2"
 
         # Test Alarm2 with SetEvent action
         alarm2 = alarms[1]

--- a/tests/reporter/excel_reporter/core/test_os_xdm.py
+++ b/tests/reporter/excel_reporter/core/test_os_xdm.py
@@ -3,14 +3,21 @@ Os Excel Reporter Tests.
 
 Implements:
     - TC_UNIT_REPORTER_00016: Os Excel Reporter - File Creation
+    - TC_UNIT_REPORTER_00017: Os Excel Reporter - Edge Cases
 
 Implements: SWR_REPORTER_00002
 """
 import os
 import tempfile
 from openpyxl import load_workbook
-from eb_model.reporter.excel_reporter.core.os_xdm import OsXdmXlsWriter
+from eb_model.models.core.abstract import EcucRefType
 from eb_model.models.core.eb_doc import EBModel
+from eb_model.models.core.os_xdm import (
+    Os, OsSpinlock, OsTask, OsApplication, OsOS, OsHooks,
+    OsMicrokernel, MkMemoryProtection, MkMemoryRegion,
+    OsScheduleTable
+)
+from eb_model.reporter.excel_reporter.core.os_xdm import OsXdmXlsWriter
 
 
 class TestOsXdmXlsWriter:
@@ -65,3 +72,257 @@ class TestOsXdmXlsWriter:
         finally:
             if os.path.exists(filename):
                 os.remove(filename)
+
+    def test_write_spinlock_multiple_accessing_apps(self):
+        """
+        Test spinlock sheet with multiple accessing applications (wrap text).
+
+        Implements: TC_UNIT_REPORTER_00017
+        """
+        writer = OsXdmXlsWriter()
+
+        with tempfile.NamedTemporaryFile(suffix='.xlsx', delete=False) as f:
+            filename = f.name
+
+        try:
+            doc = EBModel.getInstance()
+            os_mod = doc.getOs()
+
+            spinlock = OsSpinlock(os_mod, "TestSpinlock")
+            spinlock.setOsSpinlockLockMethod("STANDARD")
+            spinlock.addOsSpinlockAccessingApplication(EcucRefType("ASPath:/Os/App1"))
+            spinlock.addOsSpinlockAccessingApplication(EcucRefType("ASPath:/Os/App2"))
+            os_mod.addOsSpinlock(spinlock)
+
+            writer.write(filename, doc)
+
+            wb = load_workbook(filename)
+            assert "OsSpinlock" in wb.sheetnames
+            sheet = wb["OsSpinlock"]
+            # Row 2 should have the spinlock data
+            assert sheet.cell(row=2, column=1).value == "TestSpinlock"
+            assert sheet.cell(row=2, column=2).value == "STANDARD"
+            wb.close()
+        finally:
+            if os.path.exists(filename):
+                os.remove(filename)
+
+    def test_write_os_task_rte_resources(self):
+        """
+        Test task sheet with RTE-pattern resources.
+
+        Implements: TC_UNIT_REPORTER_00017
+        """
+        writer = OsXdmXlsWriter()
+
+        with tempfile.NamedTemporaryFile(suffix='.xlsx', delete=False) as f:
+            filename = f.name
+
+        try:
+            doc = EBModel.getInstance()
+            os_mod = doc.getOs()
+
+            # Create an application for task mapping.
+            # The ref's short name (last path segment) must match the task name.
+            app = OsApplication(os_mod, "App1")
+            app.setOsTrusted(True)
+            app.setOsApplicationCoreAssignment(0)
+            app.addOsAppTaskRef(EcucRefType("/Os/TaskRte"))
+            os_mod.addOsApplication(app)
+
+            task = OsTask(os_mod, "TaskRte")
+            task.setOsTaskPriority(10)
+            task.setOsTaskActivation(1)
+            task.setOsTaskSchedule("FULL")
+            task.setOsStacksize(1024)
+            # Add RTE-pattern resources (lines 161-162)
+            task.addOsTaskResourceRef(EcucRefType("Rte_CanIf"))
+            task.addOsTaskResourceRef(EcucRefType("Rte_Com"))
+            # Add non-RTE resource that should be filtered
+            task.addOsTaskResourceRef(EcucRefType("Res_Standard"))
+            os_mod.addOsTask(task)
+
+            writer.write(filename, doc)
+
+            wb = load_workbook(filename)
+            assert "OsTask" in wb.sheetnames
+            sheet = wb["OsTask"]
+            # Row 2 should have the task data
+            assert sheet.cell(row=2, column=1).value == "TaskRte"
+            # Column 9 should contain RTE resources (2 items, wrapped)
+            cell_value = sheet.cell(row=2, column=9).value
+            assert cell_value is not None
+            assert "Rte_CanIf" in cell_value
+            assert "Rte_Com" in cell_value
+            # Non-RTE resource should not be in the cell
+            assert "Res_Standard" not in cell_value
+            wb.close()
+        finally:
+            if os.path.exists(filename):
+                os.remove(filename)
+
+    def test_write_os_task_many_rte_resources(self):
+        """
+        Test task sheet with >10 RTE resources (Total: N summary).
+
+        Implements: TC_UNIT_REPORTER_00017
+        """
+        writer = OsXdmXlsWriter()
+
+        with tempfile.NamedTemporaryFile(suffix='.xlsx', delete=False) as f:
+            filename = f.name
+
+        try:
+            doc = EBModel.getInstance()
+            os_mod = doc.getOs()
+
+            # Create an application for task mapping
+            app = OsApplication(os_mod, "App1")
+            app.setOsTrusted(True)
+            app.setOsApplicationCoreAssignment(0)
+            app.addOsAppTaskRef(EcucRefType("/Os/TaskManyRte"))
+            os_mod.addOsApplication(app)
+
+            task = OsTask(os_mod, "TaskManyRte")
+            task.setOsTaskPriority(5)
+            task.setOsTaskActivation(1)
+            task.setOsTaskSchedule("FULL")
+            task.setOsStacksize(4096)
+            # Add 12 RTE-pattern resources (>10 triggers total summary on line 165)
+            for i in range(12):
+                task.addOsTaskResourceRef(EcucRefType("Rte_Resource_%d" % i))
+            os_mod.addOsTask(task)
+
+            writer.write(filename, doc)
+
+            wb = load_workbook(filename)
+            assert "OsTask" in wb.sheetnames
+            sheet = wb["OsTask"]
+            # Column 9 should show total count summary
+            cell_value = sheet.cell(row=2, column=9).value
+            assert cell_value is not None
+            assert "Total: 12 OsResources" in cell_value
+            wb.close()
+        finally:
+            if os.path.exists(filename):
+                os.remove(filename)
+
+    def test_write_os_os_and_hooks(self):
+        """
+        Test OsOS and OsHooks sheets are produced when data exists.
+
+        Implements: TC_UNIT_REPORTER_00017
+        """
+        writer = OsXdmXlsWriter()
+
+        with tempfile.NamedTemporaryFile(suffix='.xlsx', delete=False) as f:
+            filename = f.name
+
+        try:
+            doc = EBModel.getInstance()
+            os_mod = doc.getOs()
+
+            os_os = OsOS(os_mod, "OsOS")
+            os_os.setOsScalabilityClass("SC1")
+            os_os.setOsNumberOfCores(2)
+            os_os.setOsStackMonitoring(True)
+            os_os.setOsUseGetServiceId(False)
+            os_os.setOsUseParameterAccess(True)
+            os_os.setOsUseResScheduler(True)
+            os_os.setOsStatus("STANDARD")
+            os_mod.setOsOS(os_os)
+
+            hooks = OsHooks(os_mod, "OsHooks")
+            hooks.setOsErrorHook(True)
+            hooks.setOsShutdownHook(False)
+            hooks.setOsStartupHook(True)
+            hooks.setOsPreTaskHook(False)
+            hooks.setOsPostTaskHook(True)
+            hooks.setOsProtectionHook(False)
+            os_mod.setOsHooks(hooks)
+
+            writer.write(filename, doc)
+
+            wb = load_workbook(filename)
+            assert "OsOS" in wb.sheetnames
+            assert "OsHooks" in wb.sheetnames
+
+            os_sheet = wb["OsOS"]
+            assert os_sheet.cell(row=2, column=1).value == "ScalabilityClass"
+            assert os_sheet.cell(row=2, column=2).value == "SC1"
+            assert os_sheet.cell(row=3, column=1).value == "NumberOfCores"
+            assert os_sheet.cell(row=3, column=2).value == 2
+
+            hooks_sheet = wb["OsHooks"]
+            assert hooks_sheet.cell(row=2, column=1).value == "ErrorHook"
+            assert hooks_sheet.cell(row=2, column=2).value == "Y"
+            wb.close()
+        finally:
+            if os.path.exists(filename):
+                os.remove(filename)
+
+    def test_write_mk_memory_regions(self):
+        """
+        Test MkMemoryRegion sheet production with microkernel data.
+
+        Implements: TC_UNIT_REPORTER_00017
+        """
+        writer = OsXdmXlsWriter()
+
+        with tempfile.NamedTemporaryFile(suffix='.xlsx', delete=False) as f:
+            filename = f.name
+
+        try:
+            doc = EBModel.getInstance()
+            os_mod = doc.getOs()
+
+            kernel = OsMicrokernel(os_mod, "OsMicrokernel")
+            protection = MkMemoryProtection(kernel, "MkMemoryProtection")
+            region = MkMemoryRegion(protection, "Region1")
+            region.setMkMemoryRegionFlags(1)
+            region.setMkMemoryRegionInitialize(True)
+            region.setMkMemoryRegionGlobal(False)
+            protection.addMkMemoryRegion(region)
+            kernel.setMkMemoryProtection(protection)
+            os_mod.setOsMicrokernel(kernel)
+
+            writer.write(filename, doc)
+
+            wb = load_workbook(filename)
+            assert "MkMemoryRegion" in wb.sheetnames
+            sheet = wb["MkMemoryRegion"]
+            assert sheet.cell(row=2, column=1).value == "Region1"
+            assert sheet.cell(row=2, column=2).value == 1
+            assert sheet.cell(row=2, column=3).value == "Y"
+            wb.close()
+        finally:
+            if os.path.exists(filename):
+                os.remove(filename)
+
+    def test_write_mk_memory_region_exists_false_paths(self):
+        """
+        Test mk_memory_region_exists returns False for missing data paths.
+
+        Implements: TC_UNIT_REPORTER_00017
+        """
+        doc = EBModel.getInstance()
+        os_mod = doc.getOs()
+        writer = OsXdmXlsWriter()
+
+        # No microkernel set
+        assert writer.mk_memory_region_exists(doc) is False
+
+        # Microkernel without protection
+        kernel = OsMicrokernel(os_mod, "OsMicrokernel")
+        os_mod.setOsMicrokernel(kernel)
+        assert writer.mk_memory_region_exists(doc) is False
+
+        # Protection without regions
+        protection = MkMemoryProtection(kernel, "MkMemoryProtection")
+        kernel.setMkMemoryProtection(protection)
+        assert writer.mk_memory_region_exists(doc) is False
+
+        # Protection with regions
+        region = MkMemoryRegion(protection, "Region1")
+        protection.addMkMemoryRegion(region)
+        assert writer.mk_memory_region_exists(doc) is True


### PR DESCRIPTION
## Summary
- Add tests for uncovered code paths in OS parser (99%) and OS reporter (100%)
- Extend MOCK_OS_XDM with all entity types: microkernel/memory regions, core config, peripheral areas, events, spinlock successor refs, hardware incrementer, autosar customization
- Remove data/Os.xdm external file dependency from tests

Closes #109