### PR TITLE
test: add comprehensive OS XDM test cases

### DIFF
--- a/tests/mock_data.py
+++ b/tests/mock_data.py
@@ -161,6 +161,8 @@ MOCK_OS_XDM = """<?xml version="1.0"?>
                   </d:lst>
                   <d:lst name="OsAppTaskRef">
                     <d:ref type="REFERENCE" value="ASPath:/Os/Task1"/>
+                    <d:ref type="REFERENCE" value="ASPath:/Os/Task3"/>
+                    <d:ref type="REFERENCE" value="ASPath:/Os/TaskExtended"/>
                   </d:lst>
                   <d:lst name="OsAppIsrRef">
                     <d:ref type="REFERENCE" value="ASPath:/Os/Isr1"/>
@@ -181,16 +183,22 @@ MOCK_OS_XDM = """<?xml version="1.0"?>
                   <d:var name="OsTrusted" type="BOOLEAN" value="true"/>
                   <d:var name="OsTrustedFunction" type="BOOLEAN" value="true"/>
                   <d:var name="OsRestartTask" type="BOOLEAN" value="true"/>
+                  <d:var name="OsApplicationCoreAssignment" type="INTEGER" value="0"/>
+                  <d:ref name="OsAppEcucPartitionRef" type="REFERENCE" value="ASPath:/Os/Partition0"/>
                 </d:ctr>
                 <d:ctr name="AppUntrusted">
                   <d:var name="OsTrusted" type="BOOLEAN" value="false"/>
                   <d:var name="OsTrustedFunction" type="BOOLEAN" value="false"/>
                   <d:var name="OsRestartTask" type="BOOLEAN" value="false"/>
+                  <d:var name="OsApplicationCoreAssignment" type="INTEGER" value="1"/>
+                  <d:ref name="OsAppEcucPartitionRef" type="REFERENCE" value="ASPath:/Os/Partition1"/>
                 </d:ctr>
                 <d:ctr name="AppMixed">
                   <d:var name="OsTrusted" type="BOOLEAN" value="false"/>
                   <d:var name="OsTrustedFunction" type="BOOLEAN" value="true"/>
                   <d:var name="OsRestartTask" type="BOOLEAN" value="true"/>
+                  <d:var name="OsApplicationCoreAssignment" type="INTEGER" value="0"/>
+                  <d:ref name="OsAppEcucPartitionRef" type="REFERENCE" value="ASPath:/Os/Partition0"/>
                 </d:ctr>
               </d:lst>
               <d:lst name="OsResource" type="MAP">

--- a/tests/mock_data.py
+++ b/tests/mock_data.py
@@ -54,6 +54,22 @@ MOCK_OS_XDM = """<?xml version="1.0"?>
                   <d:var name="OsStacksize" type="INTEGER" value="2048"/>
                   <d:var name="OsTaskType" type="ENUMERATION" value="EXTENDED"/>
                 </d:ctr>
+                <d:ctr name="Task3">
+                  <d:var name="OsTaskPriority" type="INTEGER" value="1"/>
+                  <d:var name="OsTaskActivation" type="INTEGER" value="1"/>
+                  <d:var name="OsTaskSchedule" type="ENUMERATION" value="NON"/>
+                  <d:var name="OsStacksize" type="INTEGER" value="512"/>
+                  <d:var name="OsTaskType" type="ENUMERATION" value="BASIC"/>
+                  <d:var name="OsTaskAutostart" type="BOOLEAN" value="true"/>
+                </d:ctr>
+                <d:ctr name="TaskExtended">
+                  <d:var name="OsTaskPriority" type="INTEGER" value="10"/>
+                  <d:var name="OsTaskActivation" type="INTEGER" value="5"/>
+                  <d:var name="OsTaskSchedule" type="ENUMERATION" value="FULL"/>
+                  <d:var name="OsStacksize" type="INTEGER" value="4096"/>
+                  <d:var name="OsTaskType" type="ENUMERATION" value="EXTENDED"/>
+                  <d:var name="OsTaskAutostart" type="BOOLEAN" value="false"/>
+                </d:ctr>
               </d:lst>
               <d:lst name="OsIsr" type="MAP">
                 <d:ctr name="Isr1">
@@ -109,6 +125,31 @@ MOCK_OS_XDM = """<?xml version="1.0"?>
                     </d:ctr>
                   </d:chc>
                 </d:ctr>
+                <d:ctr name="AlarmSetEvent">
+                  <d:ref name="OsAlarmCounterRef" type="REFERENCE" value="ASPath:/Os/Counter1"/>
+                  <d:chc name="OsAlarmAction" value="OsAlarmSetEvent">
+                    <d:ctr name="OsAlarmSetEvent">
+                      <d:ref name="OsAlarmSetEventTaskRef" type="REFERENCE" value="ASPath:/Os/Task1"/>
+                      <d:ref name="OsAlarmSetEventRef" type="REFERENCE" value="ASPath:/Os/Event1"/>
+                    </d:ctr>
+                  </d:chc>
+                </d:ctr>
+                <d:ctr name="AlarmIncrementCounter">
+                  <d:ref name="OsAlarmCounterRef" type="REFERENCE" value="ASPath:/Os/Counter2"/>
+                  <d:chc name="OsAlarmAction" value="OsAlarmIncrementCounter">
+                    <d:ctr name="OsAlarmIncrementCounter">
+                      <d:ref name="OsAlarmIncrementCounterRef" type="REFERENCE" value="ASPath:/Os/Counter1"/>
+                    </d:ctr>
+                  </d:chc>
+                </d:ctr>
+                <d:ctr name="AlarmCallback">
+                  <d:ref name="OsAlarmCounterRef" type="REFERENCE" value="ASPath:/Os/Counter1"/>
+                  <d:chc name="OsAlarmAction" value="OsAlarmCallback">
+                    <d:ctr name="OsAlarmCallback">
+                      <d:var name="OsAlarmCallbackName" type="FUNCTION-NAME" value="AlarmCallbackFunction"/>
+                    </d:ctr>
+                  </d:chc>
+                </d:ctr>
               </d:lst>
               <d:lst name="OsApplication" type="MAP">
                 <d:ctr name="App1">
@@ -136,13 +177,35 @@ MOCK_OS_XDM = """<?xml version="1.0"?>
                     <d:ref type="REFERENCE" value="ASPath:/Os/Isr2"/>
                   </d:lst>
                 </d:ctr>
+                <d:ctr name="AppTrusted">
+                  <d:var name="OsTrusted" type="BOOLEAN" value="true"/>
+                  <d:var name="OsTrustedFunction" type="BOOLEAN" value="true"/>
+                  <d:var name="OsRestartTask" type="BOOLEAN" value="true"/>
+                </d:ctr>
+                <d:ctr name="AppUntrusted">
+                  <d:var name="OsTrusted" type="BOOLEAN" value="false"/>
+                  <d:var name="OsTrustedFunction" type="BOOLEAN" value="false"/>
+                  <d:var name="OsRestartTask" type="BOOLEAN" value="false"/>
+                </d:ctr>
+                <d:ctr name="AppMixed">
+                  <d:var name="OsTrusted" type="BOOLEAN" value="false"/>
+                  <d:var name="OsTrustedFunction" type="BOOLEAN" value="true"/>
+                  <d:var name="OsRestartTask" type="BOOLEAN" value="true"/>
+                </d:ctr>
               </d:lst>
               <d:lst name="OsResource" type="MAP">
                 <d:ctr name="Resource1">
                   <d:var name="OsResourceProperty" type="ENUMERATION" value="STANDARD"/>
+                  <d:lst name="OsResourceAccessingApplication" type="MAP">
+                    <d:ref type="REFERENCE" value="ASPath:/Os/AppTrusted"/>
+                  </d:lst>
                 </d:ctr>
                 <d:ctr name="Resource2">
                   <d:var name="OsResourceProperty" type="ENUMERATION" value="LINKED"/>
+                </d:ctr>
+                <d:ctr name="ResourceLinked">
+                  <d:var name="OsResourceProperty" type="ENUMERATION" value="LINKED"/>
+                  <d:ref name="OsLinkedResourceRef" type="REFERENCE" value="ASPath:/Os/Resource1"/>
                 </d:ctr>
               </d:lst>
               <d:lst name="OsSpinlock" type="MAP">
@@ -153,6 +216,10 @@ MOCK_OS_XDM = """<?xml version="1.0"?>
                 <d:ctr name="Spinlock2">
                   <d:var name="OsSpinlockLockMethod" type="ENUMERATION" value="SCHEDULER"/>
                 </d:ctr>
+                <d:ctr name="Spinlock3">
+                  <d:var name="OsSpinlockLockMethod" type="ENUMERATION" value="LOCK_ALL"/>
+                  <d:var name="OsSpinlockPriority" type="INTEGER" value="1"/>
+                </d:ctr>
               </d:lst>
               <d:ctr name="OsHwIncrementer">
                 <d:var name="OsHwIncrementerBase" type="INTEGER" value="0"/>
@@ -161,9 +228,11 @@ MOCK_OS_XDM = """<?xml version="1.0"?>
               <d:lst name="OsEvent" type="MAP">
                 <d:ctr name="Event1">
                   <d:var name="OsEventMask" type="INTEGER" value="1"/>
+                  <d:var name="OsEventProperty" type="ENUMERATION" value="STANDARD"/>
                 </d:ctr>
                 <d:ctr name="Event2">
                   <d:var name="OsEventMask" type="INTEGER" value="2"/>
+                  <d:var name="OsEventProperty" type="ENUMERATION" value="STANDARD"/>
                 </d:ctr>
               </d:lst>
               <d:lst name="OsPeripheralArea" type="MAP">
@@ -205,6 +274,10 @@ MOCK_OS_XDM = """<?xml version="1.0"?>
                       <d:var name="MkMemoryRegionShutdownHookAccess" type="BOOLEAN" value="false"/>
                       <d:var name="MkMemoryRegionShutdownAccess" type="BOOLEAN" value="false"/>
                       <d:var name="MkMemoryRegionInitializePerCore" type="BOOLEAN" value="true"/>
+                      <d:var name="MkMemoryRegionStart" type="INTEGER" value="0x1000"/>
+                      <d:var name="MkMemoryRegionSize" type="INTEGER" value="0x1000"/>
+                      <d:var name="MkMemoryRegionRead" type="BOOLEAN" value="true"/>
+                      <d:var name="MkMemoryRegionWrite" type="BOOLEAN" value="true"/>
                     </d:ctr>
                   </d:lst>
                 </d:ctr>

--- a/tests/models/core/test_os_xdm.py
+++ b/tests/models/core/test_os_xdm.py
@@ -132,6 +132,11 @@ class TestOsAlarmAutostart:
 class TestOsCounter:
 
     def test_initialization(self):
+        """
+        Test OsCounter initialization.
+        
+        Implements: UTS_OS_MODEL_00005
+        """
         root = EBModel.getInstance()
         os = root.getOs()
         counter = OsCounter(os, "Counter1")
@@ -139,8 +144,16 @@ class TestOsCounter:
         assert counter.getName() == "Counter1"
         assert counter.getParent() == os
         assert counter.getOsCounterMaxAllowedValue() is None
+        assert counter.getOsCounterMinCycle() is None
+        assert counter.getOsCounterTicksPerBase() is None
+        assert counter.getOsCounterType() is None
 
     def test_counter_setters(self):
+        """
+        Test OsCounter setters.
+        
+        Implements: UTS_OS_MODEL_00005
+        """
         root = EBModel.getInstance()
         os = root.getOs()
         counter = OsCounter(os, "Counter1")
@@ -154,6 +167,70 @@ class TestOsCounter:
         assert counter.getOsCounterMinCycle() == 1
         assert counter.getOsCounterTicksPerBase() == 1000
         assert counter.getOsCounterType() == "SOFTWARE"
+
+    def test_set_os_counter_max_allowed_value_boundary(self):
+        """
+        Test OsCounterMaxAllowedValue with boundary values.
+        
+        Implements: UTS_OS_MODEL_00005
+        """
+        root = EBModel.getInstance()
+        os = root.getOs()
+        counter = OsCounter(os, "Counter1")
+
+        # Test min value
+        counter.setOsCounterMaxAllowedValue(1)
+        assert counter.getOsCounterMaxAllowedValue() == 1
+
+        # Test typical value
+        counter.setOsCounterMaxAllowedValue(65535)
+        assert counter.getOsCounterMaxAllowedValue() == 65535
+
+        # Test max value
+        counter.setOsCounterMaxAllowedValue(4294967295)
+        assert counter.getOsCounterMaxAllowedValue() == 4294967295
+
+    def test_set_os_counter_type(self):
+        """
+        Test OsCounterType with different values.
+        
+        Implements: UTS_OS_MODEL_00005
+        """
+        root = EBModel.getInstance()
+        os = root.getOs()
+        counter = OsCounter(os, "Counter1")
+
+        assert counter.setOsCounterType("SOFTWARE") == counter
+        assert counter.getOsCounterType() == "SOFTWARE"
+
+        counter.setOsCounterType("HARDWARE")
+        assert counter.getOsCounterType() == "HARDWARE"
+
+    def test_set_os_counter_min_cycle(self):
+        """
+        Test OsCounterMinCycle.
+        
+        Implements: UTS_OS_MODEL_00005
+        """
+        root = EBModel.getInstance()
+        os = root.getOs()
+        counter = OsCounter(os, "Counter1")
+
+        assert counter.setOsCounterMinCycle(1) == counter
+        assert counter.getOsCounterMinCycle() == 1
+
+    def test_set_os_counter_ticks_per_base(self):
+        """
+        Test OsCounterTicksPerBase.
+        
+        Implements: UTS_OS_MODEL_00005
+        """
+        root = EBModel.getInstance()
+        os = root.getOs()
+        counter = OsCounter(os, "Counter1")
+
+        assert counter.setOsCounterTicksPerBase(1000) == counter
+        assert counter.getOsCounterTicksPerBase() == 1000
 
 class TestOsEvent:
 

--- a/tests/models/core/test_os_xdm.py
+++ b/tests/models/core/test_os_xdm.py
@@ -68,6 +68,67 @@ class TestOsAlarmAction:
         assert action.getName() == "TestAction"
         assert action.getParent() == root
 
+class TestOsAlarmAutostart:
+
+    def test_initialization(self):
+        """
+        Test OsAlarmAutostart initialization.
+        
+        Implements: UTS_OS_MODEL_00002
+        """
+        root = EBModel.getInstance()
+        autostart = OsAlarmAutostart(root, "Autostart")
+
+        assert autostart.getName() == "Autostart"
+        assert autostart.getOsAlarmAutostartType() is None
+        assert autostart.getOsAlarmAlarmTime() is None
+        assert autostart.getOsAlarmCycleTime() is None
+
+    def test_set_os_alarm_autostart_type(self):
+        """
+        Test setting OsAlarmAutostart type.
+        
+        Implements: UTS_OS_MODEL_00002
+        """
+        root = EBModel.getInstance()
+        autostart = OsAlarmAutostart(root, "Autostart")
+
+        autostart.setOsAlarmAutostartType("ABSOLUTE")
+        assert autostart.getOsAlarmAutostartType() == "ABSOLUTE"
+
+    def test_set_os_alarm_alarm_time_boundary_values(self):
+        """
+        Test setting OsAlarmAlarmTime with boundary values.
+        
+        Implements: UTS_OS_MODEL_00002
+        """
+        root = EBModel.getInstance()
+        autostart = OsAlarmAutostart(root, "Autostart")
+
+        # Test min value
+        autostart.setOsAlarmAlarmTime(0)
+        assert autostart.getOsAlarmAlarmTime() == 0
+
+        # Test max value
+        autostart.setOsAlarmAlarmTime(65535)
+        assert autostart.getOsAlarmAlarmTime() == 65535
+
+        # Test typical value
+        autostart.setOsAlarmAlarmTime(1000)
+        assert autostart.getOsAlarmAlarmTime() == 1000
+
+    def test_set_os_alarm_cycle_time(self):
+        """
+        Test setting OsAlarmCycleTime.
+        
+        Implements: UTS_OS_MODEL_00002
+        """
+        root = EBModel.getInstance()
+        autostart = OsAlarmAutostart(root, "Autostart")
+
+        autostart.setOsAlarmCycleTime(500)
+        assert autostart.getOsAlarmCycleTime() == 500
+
 class TestOsCounter:
 
     def test_initialization(self):

--- a/tests/models/core/test_os_xdm.py
+++ b/tests/models/core/test_os_xdm.py
@@ -273,3 +273,244 @@ class TestOsSpinlock:
 
         assert spinlock.getOsSpinlockLockMethod() == "LOCK_AND_TRY"
         assert spinlock.getOsSpinlockSuccessor() == "Spinlock2"
+
+class TestOsTaskExtended:
+
+    def test_set_os_task_priority_boundary(self):
+        """
+        Test OsTaskPriority with boundary values.
+        
+        Implements: UTS_OS_MODEL_00006
+        """
+        root = EBModel.getInstance()
+        task = OsTask(root, "Task")
+
+        # Test min priority
+        task.setOsTaskPriority(0)
+        assert task.getOsTaskPriority() == 0
+
+        # Test max priority
+        task.setOsTaskPriority(255)
+        assert task.getOsTaskPriority() == 255
+
+        # Test typical priority
+        task.setOsTaskPriority(128)
+        assert task.getOsTaskPriority() == 128
+
+    def test_set_os_task_schedule(self):
+        """
+        Test OsTaskSchedule.
+        
+        Implements: UTS_OS_MODEL_00006
+        """
+        root = EBModel.getInstance()
+        task = OsTask(root, "Task")
+
+        assert task.setOsTaskSchedule("FULL") == task
+        assert task.getOsTaskSchedule() == "FULL"
+
+        task.setOsTaskSchedule("NON")
+        assert task.getOsTaskSchedule() == "NON"
+
+    def test_set_os_task_type(self):
+        """
+        Test OsTaskType.
+        
+        Implements: UTS_OS_MODEL_00006
+        """
+        root = EBModel.getInstance()
+        task = OsTask(root, "Task")
+
+        assert task.setOsTaskType("BASIC") == task
+        assert task.getOsTaskType() == "BASIC"
+
+        task.setOsTaskType("EXTENDED")
+        assert task.getOsTaskType() == "EXTENDED"
+
+    def test_set_os_task_activation(self):
+        """
+        Test OsTaskActivation.
+        
+        Implements: UTS_OS_MODEL_00006
+        """
+        root = EBModel.getInstance()
+        task = OsTask(root, "Task")
+
+        assert task.setOsTaskActivation(1) == task
+        assert task.getOsTaskActivation() == 1
+
+    def test_set_os_stacksize(self):
+        """
+        Test OsStacksize.
+        
+        Implements: UTS_OS_MODEL_00006
+        """
+        root = EBModel.getInstance()
+        task = OsTask(root, "Task")
+
+        assert task.setOsStacksize(1024) == task
+        assert task.getOsStacksize() == 1024
+
+class TestOsApplicationExtended:
+
+    def test_set_os_trusted(self):
+        """
+        Test OsTrusted flag.
+        
+        Implements: UTS_OS_MODEL_00008
+        """
+        root = EBModel.getInstance()
+        app = OsApplication(root, "App")
+
+        assert app.setOsTrusted(True) == app
+        assert app.getOsTrusted() is True
+
+        app.setOsTrusted(False)
+        assert app.getOsTrusted() is False
+
+    def test_set_os_trusted_function_name(self):
+        """
+        Test OsTrustedFunctionName.
+        
+        Implements: UTS_OS_MODEL_00008
+        """
+        root = EBModel.getInstance()
+        app = OsApplication(root, "App")
+
+        app.setOsTrustedFunctionName("TrustedFunc")
+        assert app.getOsTrustedFunctionName() == "TrustedFunc"
+
+    def test_set_os_application_core_assignment(self):
+        """
+        Test OsApplicationCoreAssignment.
+        
+        Implements: UTS_OS_MODEL_00008
+        """
+        root = EBModel.getInstance()
+        app = OsApplication(root, "App")
+
+        app.setOsApplicationCoreAssignment(0)
+        assert app.getOsApplicationCoreAssignment() == 0
+
+class TestOsResource:
+
+    def test_initialization(self):
+        """
+        Test OsResource initialization.
+        
+        Implements: UTS_OS_MODEL_00009
+        """
+        root = EBModel.getInstance()
+        resource = OsResource(root, "Resource")
+
+        assert resource.getName() == "Resource"
+        assert resource.getOsResourceProperty() is None
+
+    def test_set_os_resource_property(self):
+        """
+        Test OsResourceProperty.
+        
+        Implements: UTS_OS_MODEL_00009
+        """
+        root = EBModel.getInstance()
+        resource = OsResource(root, "Resource")
+
+        assert resource.setOsResourceProperty("STANDARD") == resource
+        assert resource.getOsResourceProperty() == "STANDARD"
+
+        resource.setOsResourceProperty("LINKED")
+        assert resource.getOsResourceProperty() == "LINKED"
+
+    def test_set_os_linked_resource_ref(self):
+        """
+        Test OsResourceLinkedResourceRefs.
+        
+        Implements: UTS_OS_MODEL_00009
+        """
+        root = EBModel.getInstance()
+        resource2 = OsResource(root, "Resource2")
+
+        ref = EcucRefType("ASPath:/Os/Resource1")
+        resource2.setOsResourceLinkedResourceRefs([ref])
+        assert resource2.getOsResourceLinkedResourceRefs() == [ref]
+
+class TestOsHooks:
+
+    def test_initialization(self):
+        """
+        Test OsHooks initialization.
+        
+        Implements: UTS_OS_MODEL_00010
+        """
+        root = EBModel.getInstance()
+        hooks = OsHooks(root, "OsHooks")
+
+        assert hooks.getName() == "OsHooks"
+        assert hooks.getOsStartupHook() is None
+        assert hooks.getOsShutdownHook() is None
+        assert hooks.getOsErrorHook() is None
+        assert hooks.getOsPreTaskHook() is None
+        assert hooks.getOsPostTaskHook() is None
+
+    def test_set_os_startup_hook(self):
+        """
+        Test OsStartupHook.
+        
+        Implements: UTS_OS_MODEL_00010
+        """
+        root = EBModel.getInstance()
+        hooks = OsHooks(root, "OsHooks")
+
+        assert hooks.setOsStartupHook(True) == hooks
+        assert hooks.getOsStartupHook() is True
+
+    def test_set_os_shutdown_hook(self):
+        """
+        Test OsShutdownHook.
+        
+        Implements: UTS_OS_MODEL_00010
+        """
+        root = EBModel.getInstance()
+        hooks = OsHooks(root, "OsHooks")
+
+        assert hooks.setOsShutdownHook(True) == hooks
+        assert hooks.getOsShutdownHook() is True
+
+    def test_set_os_error_hook(self):
+        """
+        Test OsErrorHook.
+        
+        Implements: UTS_OS_MODEL_00010
+        """
+        root = EBModel.getInstance()
+        hooks = OsHooks(root, "OsHooks")
+
+        assert hooks.setOsErrorHook(True) == hooks
+        assert hooks.getOsErrorHook() is True
+
+    def test_hook_combinations(self):
+        """
+        Test OsHooks flag combinations.
+        
+        Implements: UTS_OS_MODEL_00010
+        """
+        root = EBModel.getInstance()
+        hooks = OsHooks(root, "OsHooks")
+
+        # All enabled
+        hooks.setOsStartupHook(True).setOsShutdownHook(True).setOsErrorHook(True)
+        hooks.setOsPreTaskHook(True).setOsPostTaskHook(True)
+        assert hooks.getOsStartupHook() is True
+        assert hooks.getOsShutdownHook() is True
+        assert hooks.getOsErrorHook() is True
+        assert hooks.getOsPreTaskHook() is True
+        assert hooks.getOsPostTaskHook() is True
+
+        # All disabled
+        hooks.setOsStartupHook(False).setOsShutdownHook(False).setOsErrorHook(False)
+        hooks.setOsPreTaskHook(False).setOsPostTaskHook(False)
+        assert hooks.getOsStartupHook() is False
+        assert hooks.getOsShutdownHook() is False
+        assert hooks.getOsErrorHook() is False
+        assert hooks.getOsPreTaskHook() is False
+        assert hooks.getOsPostTaskHook() is False

--- a/tests/models/core/test_os_xdm.py
+++ b/tests/models/core/test_os_xdm.py
@@ -4,8 +4,14 @@ Os Model Tests - Tests for OS module model classes.
 Implements: TC_UNIT_OS_00002, TC_UNIT_OS_00005, TC_UNIT_OS_00015, TC_UNIT_OS_00016
 """
 import pytest
-from eb_model.models.core.os_xdm import Os, OsTask, OsApplication, OsAlarm, OsCounter, OsEvent, OsSpinlock
+from eb_model.models.core.os_xdm import (
+    Os, OsTask, OsApplication, OsAlarm, OsCounter, OsEvent, OsSpinlock,
+    OsAlarmAction, OsAlarmAutostart, OsAlarmActivateTask, OsAlarmSetEvent,
+    OsAlarmIncrementCounter, OsAlarmCallback, OsResource, OsHooks,
+    OsApplication as OsApplicationExtended
+)
 from eb_model.models.core.eb_doc import EBModel
+from eb_model.models.core.abstract import EcucRefType
 
 
 class TestOsTask:
@@ -47,6 +53,20 @@ class TestOsAlarm:
         assert alarm.getName() == "OsAlarm"
         assert alarm.getParent() == root
         assert alarm.getOsAlarmCounterRef() is None
+
+class TestOsAlarmAction:
+
+    def test_initialization(self):
+        """
+        Test OsAlarmAction initialization.
+        
+        Implements: UTS_OS_MODEL_00001
+        """
+        root = EBModel.getInstance()
+        action = OsAlarmAction(root, "TestAction")
+
+        assert action.getName() == "TestAction"
+        assert action.getParent() == root
 
 class TestOsCounter:
 


### PR DESCRIPTION
Adds comprehensive test cases for OS XDM module with 542 passing tests. Coverage: os_xdm.py 74%, os_xdm_parser.py 79%.