### PR TITLE
docs: Add Read the Docs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,23 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version, and other tools you might need
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.13"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# Optionally, but recommended,
+# declare the Python requirements required to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#    install:
+#    - requirements: docs/requirements.txt
+        


### PR DESCRIPTION
## Summary

Add Read the Docs configuration file to enable automatic documentation building and hosting.

## Changes

- Add `.readthedocs.yaml` configuration file
- Configure Python 3.13 build environment on Ubuntu 24.04
- Set up Sphinx documentation build

## Benefits

- ✅ Automatic documentation builds on every commit
- ✅ Professional documentation hosting
- ✅ Versioned documentation for releases
- ✅ Better documentation accessibility for users

## Testing

- [ ] Documentation builds successfully on Read the Docs
- [ ] Documentation is accessible via Read the Docs URL

## Related Issue

Closes #125