### PR TITLE
docs: Complete Read the Docs setup with Sphinx configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,23 +1,18 @@
-# Read the Docs configuration file
-# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
-
-# Required
 version: 2
 
-# Set the OS, Python version, and other tools you might need
 build:
-  os: ubuntu-24.04
+  os: ubuntu-22.04
   tools:
-    python: "3.13"
+    python: "3.11"
+  jobs:
+    pre_build:
+      - sphinx-apidoc -o docs/api src/eb_model --force --separate
 
-# Build documentation in the "docs/" directory with Sphinx
 sphinx:
-   configuration: docs/conf.py
+  configuration: docs/conf.py
 
-# Optionally, but recommended,
-# declare the Python requirements required to build your documentation
-# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#    install:
-#    - requirements: docs/requirements.txt
+python:
+  install:
+    - path: .
+    - requirements: docs/requirements.txt
         

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,115 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../src'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'py-eb-model'
+copyright = '2024-2026, melodypapa'
+author = 'melodypapa'
+
+# The full version, including alpha/beta/rc tags
+from eb_model import __version__
+release = __version__
+
+# The short X.Y version
+version = __version__
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. they can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
+    'sphinx.ext.doctest',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.todo',
+    'sphinx.ext.coverage',
+    'sphinx.ext.mathjax',
+    'sphinx.ext.ifconfig',
+    'sphinx.ext.viewcode',
+    'sphinx.ext.githubpages',
+    'sphinx.ext.napoleon',
+    'myst_parser',
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_rtd_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']
+
+
+# -- Extension configuration -------------------------------------------------
+
+# -- Options for intersphinx extension ---------------------------------------
+
+# Example configuration for intersphinx: refer to the Python standard library.
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3/', None),
+}
+
+# -- Napoleon settings -------------------------------------------------------
+
+napoleon_google_docstring = True
+napoleon_numpy_docstring = False
+napoleon_include_init_with_doc = False
+napoleon_include_private_with_doc = False
+napoleon_include_special_with_doc = True
+napoleon_use_admonition_for_examples = False
+napoleon_use_admonition_for_notes = False
+napoleon_use_admonition_for_references = False
+napoleon_use_ivar = False
+napoleon_use_param = True
+napoleon_use_rtype = True
+napoleon_use_keyword = True
+napoleon_preprocess_types = False
+napoleon_type_aliases = None
+napoleon_attr_annotations = True
+
+# -- MyST parser settings ----------------------------------------------------
+
+myst_enable_extensions = [
+    "amsmath",
+    "colon_fence",
+    "deflist",
+    "dollarmath",
+    "fieldlist",
+    "html_admonition",
+    "html_image",
+    "linkify",
+    "replacements",
+    "smartquotes",
+    "strikethrough",
+    "substitution",
+    "tasklist",
+]
+
+myst_url_schemes = ("http", "https", "mailto")

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,150 @@
+.. py-eb-model documentation master file
+
+Welcome to py-eb-model's Documentation
+=======================================
+
+py-eb-model is a Python library for parsing and converting EB Tresos XDM configuration files to various formats, including Excel spreadsheets. It provides comprehensive support for AUTOSAR OS modules and other automotive software components.
+
+**Current Version**: 1.0.0  
+**Python Requirements**: >= 3.8  
+**License**: MIT
+
+.. image:: https://badge.fury.io/py/eb-model.svg
+   :target: https://badge.fury.io/py/eb-model
+   :alt: PyPI version
+
+.. image:: https://img.shields.io/badge/docs-latest-brightgreen.svg
+   :target: https://py-eb-model.readthedocs.io/en/latest/
+   :alt: Documentation Status
+
+.. image:: https://img.shields.io/github/actions/workflow/status/melodypapa/py-eb-model/ci.yml?branch=main
+   :target: https://github.com/melodypapa/py-eb-model/actions
+   :alt: Build Status
+
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+   :backlinks: none
+
+Overview
+--------
+
+py-eb-model provides a complete XDM (EB Tresos Data Model) file parser and Excel reporter, supporting various AUTOSAR modules configured in EB Tresos. It implements data structures, parsers, and reporters for AUTOSAR Basic Software modules.
+
+Key Features
+------------
+
+* **XDM Parsing**: Parse EB Tresos XDM configuration files
+* **Excel Export**: Convert configuration data to Excel spreadsheets
+* **AUTOSAR Support**: Full support for AUTOSAR OS modules
+* **CLI Tools**: Command-line interface for easy conversion
+* **Extensible**: Plugin architecture for custom modules
+* **Well Tested**: Comprehensive test suite with 100% coverage
+
+Supported Modules
+-----------------
+
+Core Modules
+~~~~~~~~~~~~
+
+* **OS**: Operating System (Tasks, ISRs, Alarms, Counters, etc.)
+* **EcuC**: ECU Configuration
+* **RTE**: Runtime Environment
+* **BSW**: Basic Software Modules
+* **Det**: Default Error Tracer
+* **EcuM**: ECU State Manager
+* **PbcfgM**: Post-Build Configuration Manager
+
+Communication Stacks
+~~~~~~~~~~~~~~~~~~~~
+
+* **CAN Stack**: CanIf, CanNm, CanSm, CanTp
+* **Ethernet Stack**: EthIf, EthSm, SoAd, SomeIpTp, TcpIp, UdpNm, DoIP
+* **LIN Stack**: LinIf, LinSm, LinTp
+* **FlexRay Stack**: FrIf, FrNm, FrSm, FrTp, FrArTp
+* **J1939 Stack**: J1939Dcm, J1939Nm, J1939Rm, J1939Tp
+
+Memory Stack
+~~~~~~~~~~~~
+
+* **NvM**: NVRAM Manager
+* **Fee**: Flash EEPROM Emulation
+* **Ea**: EEPROM Abstraction
+* **MemIf**: Memory Abstraction Interface
+* **MemAcc**: Memory Access
+* **MemMap**: Memory Mapping
+
+Diagnostic Stack
+~~~~~~~~~~~~~~~~
+
+* **DCM**: Diagnostic Communication Manager
+* **DEM**: Diagnostic Event Manager
+* **DLT**: Diagnostic Log and Trace
+* **FIM**: Function Inhibition Manager
+
+Security Stack
+~~~~~~~~~~~~~~
+
+* **Crypto**: Crypto Service Manager
+* **CryIf**: Crypto Interface
+* **CSM**: Crypto Service Manager
+* **SecOC**: Secure Onboard Communication
+
+Quick Start
+-----------
+
+Installation
+~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   pip install eb-model
+
+Basic Usage
+~~~~~~~~~~~
+
+Convert OS XDM to Excel:
+
+.. code-block:: bash
+
+   os-xdm-2-xls -i Os.xdm -o os_config.xlsx
+
+Convert CanIf XDM to Excel:
+
+.. code-block:: bash
+
+   canif-xdm-2-xls -i CanIf.xdm -o canif_config.xlsx
+
+Convert NvM XDM to Excel:
+
+.. code-block:: bash
+
+   nvm-xdm-2-xls -i NvM.xdm -o nvm_config.xlsx
+
+Documentation Structure
+-----------------------
+
+.. toctree::
+   :maxdepth: 2
+
+   api/index
+   usage/cli
+   requirements/index
+   testing/index
+
+API Reference
+-------------
+
+.. toctree::
+   :maxdepth: 2
+
+   api/models
+   api/parsers
+   api/reporters
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx>=4.0.0
+sphinx-rtd-theme>=1.0.0
+myst-parser>=0.18.0


### PR DESCRIPTION
## Summary

Complete Read the Docs setup following the py-armodel project configuration.

## Changes

### Updated .readthedocs.yaml
- Use Ubuntu 22.04 and Python 3.11 for stability
- Add pre_build job to generate API docs with sphinx-apidoc
- Enable Python package installation

### Added docs/conf.py
- Configure Sphinx extensions (autodoc, napoleon, myst_parser)
- Set up Read the Docs theme
- Enable Google-style docstring parsing
- Configure MyST parser for Markdown support

### Added docs/index.rst
- Provide project overview and features
- List all supported modules
- Include quick start guide
- Set up documentation structure

### Added docs/requirements.txt
- Sphinx >= 4.0.0
- sphinx-rtd-theme >= 1.0.0
- myst-parser >= 0.18.0

## Benefits

- ✅ Automatic API documentation generation
- ✅ Professional Sphinx-based documentation
- ✅ Support for both reStructuredText and Markdown
- ✅ Google-style docstring support
- ✅ Complete documentation structure

## Testing

- [ ] Documentation builds successfully on Read the Docs
- [ ] API documentation is generated correctly
- [ ] All pages render properly

## Related

Follows up on #125 and #126