### PR TITLE
docs: Add API Reference section to sidebar navigation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -126,21 +126,17 @@ Documentation Structure
 
 .. toctree::
    :maxdepth: 2
+   :caption: User Guide
 
-   api/index
    usage/cli
    requirements/index
    testing/index
 
-API Reference
--------------
-
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 3
+   :caption: API Reference
 
-   api/models
-   api/parsers
-   api/reporters
+   api/modules
 
 Indices and tables
 ==================


### PR DESCRIPTION
Add dedicated API Reference section to sidebar navigation for easier access to API documentation.