### PR TITLE
feat: Add combined variant for XDM model generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,4 @@ cython_debug/
 # Project specific
 archive/
 data/
+doc

--- a/src/eb_model/generator/cli.py
+++ b/src/eb_model/generator/cli.py
@@ -9,7 +9,7 @@ import xml.etree.ElementTree as ET
 
 from .schema_parser import SchemaParser
 from .data_generator import DataGenerator
-from .strategies import DefaultsStrategy, BoundaryStrategy, RandomStrategy
+from .strategies import DefaultsStrategy, BoundaryStrategy, RandomStrategy, CombinedStrategy
 
 
 def create_parser() -> argparse.ArgumentParser:
@@ -29,9 +29,9 @@ def create_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         '--variant',
-        choices=['defaults', 'boundary', 'random'],
-        default='defaults',
-        help='Value generation variant (default: defaults)',
+        choices=['combined', 'defaults', 'boundary', 'random'],
+        default='combined',
+        help='Value generation variant (default: combined)',
     )
     parser.add_argument(
         '--seed',
@@ -51,6 +51,7 @@ def create_parser() -> argparse.ArgumentParser:
 def getStrategy(variant: str, seed=None):
     """Get the appropriate strategy for the variant."""
     strategies = {
+        'combined': CombinedStrategy,
         'defaults': DefaultsStrategy,
         'boundary': BoundaryStrategy,
         'random': RandomStrategy,
@@ -58,7 +59,7 @@ def getStrategy(variant: str, seed=None):
     cls = strategies.get(variant)
     if cls is None:
         raise ValueError("Unknown variant: %s" % variant)
-    return cls(seed=seed) if variant == 'random' else cls()
+    return cls(seed=seed) if variant in ('random', 'combined') else cls()
 
 
 def main(args=None) -> int:

--- a/src/eb_model/generator/data_generator.py
+++ b/src/eb_model/generator/data_generator.py
@@ -9,7 +9,7 @@ from typing import Optional
 from .schema_model import (
     SchemaChc, SchemaCtr, SchemaLst, SchemaRef, SchemaRoot, SchemaVar,
 )
-from .strategies import DefaultsStrategy
+from .strategies import DefaultsStrategy, CombinedStrategy
 
 
 # Standard XDM namespaces
@@ -39,6 +39,10 @@ class DataGenerator:
         # Register d: prefix so ET uses it instead of auto-generated ns0
         if d_ns:
             ET.register_namespace('d', d_ns)
+        # Register a: prefix for ENABLE attributes
+        a_ns = ns.get('a', '')
+        if a_ns:
+            ET.register_namespace('a', a_ns)
         self._ns_for_output = dict(ns)
 
         # Build datamodel root
@@ -102,12 +106,28 @@ class DataGenerator:
         if value:
             elem.set('value', value)
 
+        # For combined variant, add ENABLE attribute to ensure optional items are active
+        if isinstance(self.strategy, CombinedStrategy):
+            a_ns = self._ns_for_output.get('a', '')
+            a_prefix = '{%s}' % a_ns if a_ns else ''
+            enable = ET.SubElement(elem, '%sa' % a_prefix)
+            enable.set('name', 'ENABLE')
+            enable.set('value', 'true')
+
     def _generate_ctr(self, ctr: SchemaCtr, parent: ET.Element, d_prefix: str) -> None:
         """Generate a d:ctr element."""
         elem = ET.SubElement(parent, '%sctr' % d_prefix)
         elem.set('name', ctr.name)
         elem.set('type', ctr.ctr_type)
         self._generate_children(ctr.children, elem, d_prefix)
+
+        # For combined variant, add ENABLE attribute to ensure optional items are active
+        if isinstance(self.strategy, CombinedStrategy):
+            a_ns = self._ns_for_output.get('a', '')
+            a_prefix = '{%s}' % a_ns if a_ns else ''
+            enable = ET.SubElement(elem, '%sa' % a_prefix)
+            enable.set('name', 'ENABLE')
+            enable.set('value', 'true')
 
     def _generate_lst(self, lst: SchemaLst, parent: ET.Element, d_prefix: str) -> None:
         """Generate a d:lst element with entries."""
@@ -117,7 +137,17 @@ class DataGenerator:
             elem.set('type', lst.lst_type)
 
         # Determine number of entries
-        num_entries = lst.min_entries
+        # If min_entries == 0: generate 2 entries (basic coverage)
+        # If min_entries > 0: generate min_entries + 2 (verify multiplicity)
+        # Cap at max_entries if set
+        if lst.min_entries == 0:
+            num_entries = 2
+        else:
+            num_entries = max(lst.min_entries + 2, 3)
+        if lst.max_entries is not None:
+            num_entries = min(num_entries, lst.max_entries)
+
+        # Override if explicit list_entries specified
         if self.list_entries is not None:
             num_entries = min(self.list_entries, lst.max_entries or self.list_entries)
 
@@ -158,15 +188,32 @@ class DataGenerator:
         if value:
             elem.set('value', value)
 
-    def _generate_chc(self, chc: SchemaChc, parent: ET.Element, d_prefix: str) -> None:
-        """Generate a d:chc element using first choice."""
-        elem = ET.SubElement(parent, '%schc' % d_prefix)
-        elem.set('name', chc.name)
-        elem.set('type', chc.chc_type)
+        # For combined variant, add ENABLE attribute to ensure optional items are active
+        if isinstance(self.strategy, CombinedStrategy):
+            a_ns = self._ns_for_output.get('a', '')
+            a_prefix = '{%s}' % a_ns if a_ns else ''
+            enable = ET.SubElement(elem, '%sa' % a_prefix)
+            enable.set('name', 'ENABLE')
+            enable.set('value', 'true')
 
-        if chc.choices:
-            first = chc.choices[0]
-            self._generate_ctr(first, elem, d_prefix)
+    def _generate_chc(self, chc: SchemaChc, parent: ET.Element, d_prefix: str) -> None:
+        """Generate a d:chc element using first choice (or all for combined variant)."""
+        # For combined variant, generate all choice options
+        if isinstance(self.strategy, CombinedStrategy) and chc.choices:
+            for choice in chc.choices:
+                elem = ET.SubElement(parent, '%schc' % d_prefix)
+                elem.set('name', chc.name)
+                elem.set('type', chc.chc_type)
+                self._generate_ctr(choice, elem, d_prefix)
+        else:
+            # Other variants: generate first choice only
+            elem = ET.SubElement(parent, '%schc' % d_prefix)
+            elem.set('name', chc.name)
+            elem.set('type', chc.chc_type)
+
+            if chc.choices:
+                first = chc.choices[0]
+                self._generate_ctr(first, elem, d_prefix)
 
     def toString(self, tree: ET.ElementTree) -> str:
         """Serialize element tree to XML string with proper namespace declarations."""
@@ -176,10 +223,10 @@ class DataGenerator:
         xml_bytes = ET.tostring(root, encoding='unicode', xml_declaration=False)
 
         # Build xmlns declarations for the root <datamodel> tag.
-        # ET already emits xmlns:d (registered prefix), so skip 'd' here.
+        # ET already emits xmlns:d and xmlns:a (registered prefixes), so skip them here.
         parts = []
         for prefix, uri in self._ns_for_output.items():
-            if prefix == 'd':
+            if prefix in ('d', 'a'):
                 continue
             if prefix:
                 parts.append('xmlns:%s="%s"' % (prefix, uri))

--- a/src/eb_model/generator/schema_model.py
+++ b/src/eb_model/generator/schema_model.py
@@ -25,6 +25,7 @@ class SchemaVar:
     range_info: Optional[SchemaRange] = None
     label: Optional[str] = None
     desc: Optional[str] = None
+    enabled: Optional[str] = None  # ENABLE data attribute value
 
 
 @dataclass
@@ -34,6 +35,7 @@ class SchemaRef:
     ref_type: str  # REFERENCE
     ref_targets: List[str] = field(default_factory=list)
     range_targets: List[str] = field(default_factory=list)
+    enabled: Optional[str] = None  # ENABLE data attribute value
 
 
 @dataclass
@@ -44,6 +46,7 @@ class SchemaCtr:
     children: List = field(default_factory=list)  # List of schema nodes
     name_pattern: Optional[str] = None
     label: Optional[str] = None
+    enabled: Optional[str] = None  # ENABLE data attribute value
 
 
 @dataclass

--- a/src/eb_model/generator/schema_parser.py
+++ b/src/eb_model/generator/schema_parser.py
@@ -126,6 +126,7 @@ class SchemaParser:
         name = element.get('name', '')
         ctr_type = element.get('type', 'IDENTIFIABLE')
         name_pattern = self._get_attribute_value(element, 'NAME_PATTERN')
+        enabled = self._get_da_value(element, 'ENABLE')
 
         children = []
         for child in element:
@@ -146,6 +147,7 @@ class SchemaParser:
             ctr_type=ctr_type,
             children=children,
             name_pattern=name_pattern,
+            enabled=enabled,
         )
 
     def _parse_var(self, element: ET.Element) -> SchemaVar:
@@ -154,6 +156,7 @@ class SchemaParser:
         var_type = element.get('type', 'STRING')
         default = self._get_da_value(element, 'DEFAULT')
         label = self._get_attribute_value(element, 'LABEL')
+        enabled = self._get_da_value(element, 'ENABLE')
         range_info = self._parse_range(element)
 
         return SchemaVar(
@@ -162,6 +165,7 @@ class SchemaParser:
             default=default,
             range_info=range_info,
             label=label,
+            enabled=enabled,
         )
 
     def _parse_lst(self, element: ET.Element) -> SchemaLst:
@@ -207,6 +211,7 @@ class SchemaParser:
         """Parse a v:ref element into SchemaRef."""
         name = element.get('name', '')
         ref_type = element.get('type', 'REFERENCE')
+        enabled = self._get_da_value(element, 'ENABLE')
 
         ref_targets = []
         range_targets = []
@@ -224,6 +229,7 @@ class SchemaParser:
             ref_type=ref_type,
             ref_targets=ref_targets,
             range_targets=range_targets,
+            enabled=enabled,
         )
 
     def _parse_chc(self, element: ET.Element) -> SchemaChc:

--- a/src/eb_model/generator/strategies.py
+++ b/src/eb_model/generator/strategies.py
@@ -121,3 +121,35 @@ class RandomStrategy:
     def generateRefValue(self, ref: SchemaRef) -> Optional[str]:
         """Generate a mock ASPath reference value."""
         return _generate_mock_refpath(ref.ref_targets, self.rng.choice)
+
+
+class CombinedStrategy:
+    """Generate values cycling through defaults, boundary, and random strategies.
+
+    Entry 0 uses defaults, entry 1 uses boundary, entry 2+ uses random.
+    This ensures comprehensive test coverage in a single generated XDM.
+
+    Implements: SWR_GEN_00003 (Combined Strategy)
+    """
+
+    def __init__(self, seed: Optional[int] = None) -> None:
+        self._counter = 0
+        self._defaults = DefaultsStrategy()
+        self._boundary = BoundaryStrategy()
+        self._random = RandomStrategy(seed)
+
+    def generateValue(self, var: SchemaVar) -> str:
+        """Generate a value cycling through defaults, boundary, random."""
+        idx = self._counter
+        self._counter += 1
+
+        if idx % 3 == 0:
+            return self._defaults.generateValue(var)
+        elif idx % 3 == 1:
+            return self._boundary.generateValue(var)
+        else:
+            return self._random.generateValue(var)
+
+    def generateRefValue(self, ref: SchemaRef) -> Optional[str]:
+        """Generate a mock ASPath reference value (random choice)."""
+        return self._random.generateRefValue(ref)

--- a/tests/generator/test_data_generator.py
+++ b/tests/generator/test_data_generator.py
@@ -4,7 +4,7 @@ from eb_model.generator.schema_model import (
     SchemaVar, SchemaCtr, SchemaLst, SchemaRef, SchemaChc, SchemaRange, SchemaRoot,
 )
 from eb_model.generator.data_generator import DataGenerator
-from eb_model.generator.strategies import DefaultsStrategy
+from eb_model.generator.strategies import DefaultsStrategy, CombinedStrategy
 
 
 class TestDataGeneratorBasic:
@@ -104,3 +104,99 @@ class TestDataGeneratorBasic:
         xml_str = gen.toString(gen.generate(root))
         parsed = ET.fromstring(xml_str)
         assert parsed is not None
+
+
+class TestDataGeneratorCombined:
+    """Tests for combined variant data generation."""
+
+    def _make_root(self, children=None):
+        """Create a minimal SchemaRoot for testing."""
+        module_def = SchemaCtr(name="TestMod", ctr_type="MODULE-DEF", children=children or [])
+        return SchemaRoot(
+            module_name="TestMod",
+            module_def=module_def,
+            version="7.0",
+            namespaces={
+                '': 'http://www.tresos.de/_projects/DataModel2/16/root.xsd',
+                'a': 'http://www.tresos.de/_projects/DataModel2/16/attribute.xsd',
+                'v': 'http://www.tresos.de/_projects/DataModel2/06/schema.xsd',
+                'd': 'http://www.tresos.de/_projects/DataModel2/06/data.xsd',
+            },
+            ar_package_name="TestPkg",
+        )
+
+    def test_list_min_zero_generates_two(self):
+        """List with min=0 generates 2 entries for combined variant."""
+        root = self._make_root([
+            SchemaLst(name="Items", lst_type="MAP", min_entries=0, max_entries=10,
+                      child=SchemaCtr(name="Item", ctr_type="IDENTIFIABLE", children=[
+                          SchemaVar(name="Val", var_type="INTEGER", default="0"),
+                      ])),
+        ])
+        gen = DataGenerator(CombinedStrategy(seed=42))
+        xml_str = gen.toString(gen.generate(root))
+        assert xml_str.count('name="Item_') == 2
+
+    def test_list_with_min_generates_extra(self):
+        """List with min=1 generates min+2=3 entries for combined variant."""
+        root = self._make_root([
+            SchemaLst(name="Items", lst_type="MAP", min_entries=1, max_entries=10,
+                      child=SchemaCtr(name="Item", ctr_type="IDENTIFIABLE", children=[
+                          SchemaVar(name="Val", var_type="INTEGER", default="0"),
+                      ])),
+        ])
+        gen = DataGenerator(CombinedStrategy(seed=42))
+        xml_str = gen.toString(gen.generate(root))
+        assert xml_str.count('name="Item_') == 3
+
+    def test_choice_generates_all_options(self):
+        """Choice generates all options for combined variant."""
+        root = self._make_root([
+            SchemaChc(name="Action", chc_type="IDENTIFIABLE", choices=[
+                SchemaCtr(name="OptionA", ctr_type="IDENTIFIABLE", children=[
+                    SchemaVar(name="ValA", var_type="BOOLEAN", default="true"),
+                ]),
+                SchemaCtr(name="OptionB", ctr_type="IDENTIFIABLE", children=[
+                    SchemaVar(name="ValB", var_type="BOOLEAN", default="false"),
+                ]),
+            ]),
+        ])
+        gen = DataGenerator(CombinedStrategy(seed=42))
+        xml_str = gen.toString(gen.generate(root))
+        # Count chc elements with name="Action" (there are 2 for the 2 options)
+        assert xml_str.count('name="Action"') == 2
+        assert 'OptionA' in xml_str
+        assert 'OptionB' in xml_str
+
+    def test_optional_items_have_enable(self):
+        """Combined variant adds ENABLE attribute to optional items."""
+        root = self._make_root([
+            SchemaVar(name="TestBool", var_type="BOOLEAN", default="true", enabled="false"),
+        ])
+        gen = DataGenerator(CombinedStrategy(seed=42))
+        xml_str = gen.toString(gen.generate(root))
+        assert 'name="ENABLE"' in xml_str
+        assert 'value="true"' in xml_str
+
+    def test_container_has_enable(self):
+        """Combined variant adds ENABLE attribute to containers."""
+        root = self._make_root([
+            SchemaCtr(name="General", ctr_type="IDENTIFIABLE", children=[
+                SchemaVar(name="Enabled", var_type="BOOLEAN", default="true"),
+            ]),
+        ])
+        gen = DataGenerator(CombinedStrategy(seed=42))
+        xml_str = gen.toString(gen.generate(root))
+        assert 'name="ENABLE"' in xml_str
+        assert 'value="true"' in xml_str
+
+    def test_reference_has_enable(self):
+        """Combined variant adds ENABLE attribute to references."""
+        root = self._make_root([
+            SchemaRef(name="TargetRef", ref_type="REFERENCE",
+                      ref_targets=["ASPathDataOfSchema:/TestMod/Cfg/Target"]),
+        ])
+        gen = DataGenerator(CombinedStrategy(seed=42))
+        xml_str = gen.toString(gen.generate(root))
+        assert 'name="ENABLE"' in xml_str
+        assert 'value="true"' in xml_str

--- a/tests/generator/test_integration.py
+++ b/tests/generator/test_integration.py
@@ -9,7 +9,7 @@ import pytest
 
 from eb_model.generator.schema_parser import SchemaParser
 from eb_model.generator.data_generator import DataGenerator
-from eb_model.generator.strategies import DefaultsStrategy, BoundaryStrategy, RandomStrategy
+from eb_model.generator.strategies import DefaultsStrategy, BoundaryStrategy, RandomStrategy, CombinedStrategy
 
 
 SCHEMA_DIR = os.path.join(os.path.dirname(__file__), '..', '..', 'doc')
@@ -97,6 +97,20 @@ class TestCanIfGeneration:
         finally:
             os.unlink(tmp_path)
 
+    @pytest.mark.skipif(not _schema_exists(CANIF_SCHEMA), reason="CanIf schema not available")
+    def test_generate_canif_combined(self):
+        """Generate CanIf model XDM with combined variant."""
+        tree = ET.parse(CANIF_SCHEMA)
+        parser = SchemaParser()
+        schema_root = parser.parse(tree.getroot())
+
+        gen = DataGenerator(CombinedStrategy(seed=42))
+        result = gen.generate(schema_root)
+        xml_str = gen.toString(result)
+        parsed = ET.fromstring(xml_str)
+        assert parsed is not None
+        assert 'ENABLE' in xml_str
+
 
 class TestOsGeneration:
     @pytest.mark.skipif(not _schema_exists(OS_SCHEMA), reason="Os schema not available")
@@ -137,3 +151,17 @@ class TestOsGeneration:
             xml_str = gen.toString(result)
             parsed = ET.fromstring(xml_str)
             assert parsed is not None
+
+    @pytest.mark.skipif(not _schema_exists(OS_SCHEMA), reason="Os schema not available")
+    def test_generate_os_combined(self):
+        """Generate Os model XDM with combined variant."""
+        tree = ET.parse(OS_SCHEMA)
+        parser = SchemaParser()
+        schema_root = parser.parse(tree.getroot())
+
+        gen = DataGenerator(CombinedStrategy(seed=42))
+        result = gen.generate(schema_root)
+        xml_str = gen.toString(result)
+        parsed = ET.fromstring(xml_str)
+        assert parsed is not None
+        assert 'ENABLE' in xml_str

--- a/tests/generator/test_strategies.py
+++ b/tests/generator/test_strategies.py
@@ -125,3 +125,75 @@ class TestRandomStrategy:
         var = SchemaVar(name="Test", var_type="STRING")
         val = self.strategy.generateValue(var)
         assert isinstance(val, str)
+
+
+class TestCombinedStrategy:
+    def setup_method(self):
+        self.strategy = RandomStrategy(seed=42)
+
+    def test_cycles_through_strategies(self):
+        from eb_model.generator.strategies import CombinedStrategy
+        strategy = CombinedStrategy(seed=42)
+
+        var = SchemaVar(name="Test", var_type="INTEGER",
+                        range_info=SchemaRange(min_value=0, max_value=100))
+
+        # Entry 0: defaults (0 for INTEGER without default)
+        val0 = strategy.generateValue(var)
+        assert val0 == "0"
+
+        # Entry 1: boundary (min_value = 0)
+        val1 = strategy.generateValue(var)
+        assert val1 == "0"
+
+        # Entry 2: random
+        val2 = strategy.generateValue(var)
+        assert isinstance(int(val2), int)
+
+        # Entry 3: back to defaults
+        val3 = strategy.generateValue(var)
+        assert val3 == "0"
+
+    def test_cycles_with_default_value(self):
+        from eb_model.generator.strategies import CombinedStrategy
+        strategy = CombinedStrategy(seed=42)
+
+        var = SchemaVar(name="Test", var_type="INTEGER", default="42",
+                        range_info=SchemaRange(min_value=0, max_value=100))
+
+        # Entry 0: defaults (uses default)
+        val0 = strategy.generateValue(var)
+        assert val0 == "42"
+
+        # Entry 1: boundary (min_value = 0)
+        val1 = strategy.generateValue(var)
+        assert val1 == "0"
+
+    def test_enum_cycles(self):
+        from eb_model.generator.strategies import CombinedStrategy
+        strategy = CombinedStrategy(seed=42)
+
+        var = SchemaVar(name="Test", var_type="ENUMERATION",
+                        range_info=SchemaRange(enum_values=["A", "B", "C"]))
+
+        # Entry 0: defaults (first enum)
+        val0 = strategy.generateValue(var)
+        assert val0 == "A"
+
+        # Entry 1: boundary (first enum)
+        val1 = strategy.generateValue(var)
+        assert val1 == "A"
+
+        # Entry 2: random (any enum)
+        val2 = strategy.generateValue(var)
+        assert val2 in ["A", "B", "C"]
+
+    def test_reference_random(self):
+        from eb_model.generator.strategies import CombinedStrategy
+        strategy = CombinedStrategy(seed=42)
+
+        ref = SchemaRef(name="TestRef", ref_type="REFERENCE",
+                        ref_targets=["ASPathDataOfSchema:/Mod/Cfg/Target"])
+        result = strategy.generateRefValue(ref)
+        assert result is not None
+        assert "ASPath:" in result


### PR DESCRIPTION
## Summary
- Add CombinedStrategy that cycles through defaults, boundary, and random values per entry
- Update list entry count logic: min=0 → 2 entries, min>0 → min+2 entries (capped at max)
- Generate all choice options for combined variant (not just first)
- Parse ENABLE data attributes and add to schema model (SchemaVar, SchemaCtr, SchemaRef)
- Generate ENABLE attributes for combined variant to include optional items
- Set combined as the default CLI variant
- Add comprehensive tests for combined variant (12 new tests)

Closes #134