### PR TITLE
docs: Add model-xdm-generator user manual

### DIFF
--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -56,3 +56,52 @@ The following legacy commands are still available but deprecated:
 - ... (52 more)
 
 Please migrate to `eb-convert` for new usage.
+
+## model-xdm-generator
+
+Generate model (instance) XDM files from schema XDM files for testing.
+
+### Usage
+
+```bash
+model-xdm-generator <schema.xdm> -o <output.xdm> [options]
+```
+
+### Examples
+
+```bash
+# Generate with combined variant (default)
+model-xdm-generator doc/canif/schema/CanIf.xdm -o CanIf_model.xdm
+
+# Generate with specific variant
+model-xdm-generator doc/os/schema/Os.xdm -o Os_model.xdm --variant boundary
+
+# Generate with seeded random values
+model-xdm-generator doc/canif/schema/CanIf.xdm -o CanIf_random.xdm --variant random --seed 42
+
+# Override list entry count
+model-xdm-generator doc/os/schema/Os.xdm -o Os_model.xdm --list-entries 5
+```
+
+### Options
+
+- `-o, --output OUTPUT`: Output path for the generated model XDM file (required)
+- `--variant {combined,defaults,boundary,random}`: Value generation variant (default: combined)
+- `--seed SEED`: Random seed for reproducible output (used with `--variant random` or `--variant combined`)
+- `--list-entries LIST_ENTRIES`: Number of entries per list (overrides MIN from schema)
+
+### Variants
+
+- **combined** (default): Generates comprehensive test data cycling through defaults, boundary, and random values. Includes all choice options and optional items with ENABLE attributes.
+- **defaults**: Uses DEFAULT values from schema, or type-specific defaults if not specified
+- **boundary**: Uses boundary values (min/max, edge cases) for comprehensive testing
+- **random**: Uses random values within RANGE constraints (use `--seed` for reproducibility)
+
+### Output
+
+The generated model XDM file contains:
+- Complete XDM structure matching the schema
+- Generated values for all variables based on the selected variant
+- Mock references for all REFERENCE types
+- Multiple list entries to verify multiplicity (2 for min=0, min+2 for min>0)
+- ENABLE attributes on all items (combined variant only)


### PR DESCRIPTION
## Summary

Add user manual documentation for the model-xdm-generator CLI tool.

Documents:
- Usage syntax and examples
- All command-line options
- Four generation variants (combined, defaults, boundary, random)
- Output format and features

Closes #136