### PR TITLE
feat: align model-xdm-generator with XDM mapping rules

### DIFF
--- a/docs/requirements/infrastructure/swr_generator.md
+++ b/docs/requirements/infrastructure/swr_generator.md
@@ -22,16 +22,16 @@ Define Python dataclasses representing XDM schema node structure for type-safe s
 | Field | Multiplicity | Type | Description | Origin |
 | --- | --- | --- | --- | --- |
 | SchemaRange | [1] | dataclass | RANGE constraints (min/max values, enum values, regex) | XDM Spec 5.1.6.4 |
-| SchemaVar | [1] | dataclass | Schema variable definition with name, type, default, range | XDM Spec 5.1.6.4 |
-| SchemaCtr | [1] | dataclass | Schema container with children list | XDM Spec 5.1.6.1 |
+| SchemaVar | [1] | dataclass | Schema variable definition with name, type, default, range, derived, optional, multiplicity | XDM Spec 5.1.6.4, 5.2.1.14.3, 5.2.5.1, 5.2.5 |
+| SchemaCtr | [1] | dataclass | Schema container with children list, optional, multiplicity, target/context (INSTANCE) | XDM Spec 5.1.6.1, 5.2.5.1, 5.2.5, 5.2.1.6.1 |
 | SchemaLst | [1] | dataclass | Schema list with MAP/empty type, MIN/MAX entries | XDM Spec 5.1.6.3 |
-| SchemaRef | [1] | dataclass | Schema reference with REF and RANGE targets | XDM Spec 5.1.6.5 |
+| SchemaRef | [1] | dataclass | Schema reference with REF and RANGE targets, optional, multiplicity | XDM Spec 5.1.6.5, 5.2.5.1, 5.2.5 |
 | SchemaChc | [1] | dataclass | Schema choice with alternative containers | XDM Spec 5.1.6.2 |
 | SchemaRoot | [1] | dataclass | Root holding module name, version, namespaces, module_def | XDM Spec 5.1.2 |
 
 **Implementation:** `generator/schema_model.py`
 **Status:** Implemented
-**Last Validated:** 2026-06-07
+**Last Validated:** 2026-06-15
 
 ---
 
@@ -52,7 +52,7 @@ Parse XDM schema files containing `v:` prefix nodes and build SchemaRoot model t
 
 **Implementation:** `generator/schema_parser.py`
 **Status:** Implemented
-**Last Validated:** 2026-06-07
+**Last Validated:** 2026-06-15
 
 ---
 
@@ -89,7 +89,7 @@ Provide pluggable strategies for generating configuration values from schema met
 
 **Implementation:** `generator/strategies.py`
 **Status:** Implemented
-**Last Validated:** 2026-06-07
+**Last Validated:** 2026-06-15
 
 ---
 
@@ -101,11 +101,14 @@ Convert schema model tree into `d:` prefix element tree following XDM data-node 
 | --- | --- | --- | --- | --- |
 | generate() | [1] | method | Generate complete model XDM ElementTree from SchemaRoot | XDM Spec 5.1.7 |
 | toString() | [1] | method | Serialize ElementTree to XML string with xmlns declarations | XDM Spec 5.1.2 |
-| _generate_var() | [0..*] | method | Generate d:var element with value from strategy; CombinedStrategy adds ENABLE=true | XDM Spec 5.1.7.4 |
-| _generate_ctr() | [0..*] | method | Generate d:ctr element with children; CombinedStrategy adds ENABLE=true | XDM Spec 5.1.7.1 |
-| _generate_lst() | [0..*] | method | Generate d:lst with MIN entries, unique names | XDM Spec 5.1.7.3 |
-| _generate_ref() | [0..*] | method | Generate d:ref with mock ASPath value; CombinedStrategy adds ENABLE=true | XDM Spec 5.1.7.5 |
-| _generate_chc() | [0..*] | method | Generate d:chc with value=selected choice name. Non-combined: first choice only; CombinedStrategy: all choices as separate d:chc elements | XDM Spec 5.1.7.2 |
+| _generate_var() | [0..*] | method | Generate d:var element with value from strategy; emit DERIVED attribute if present | XDM Spec 5.1.7.4, 5.2.1.14.3 |
+| _generate_ctr() | [0..*] | method | Generate d:ctr element with children; preserve INSTANCE TARGET/CONTEXT | XDM Spec 5.1.7.1, 5.2.1.6.1 |
+| _generate_lst() | [0..*] | method | Generate d:lst with MIN entries, unique names; special-case optional singleton (MIN=0, MAX=1) | XDM Spec 5.1.7.3, 5.2.5.1 |
+| _generate_ref() | [0..*] | method | Generate d:ref with mock ASPath value | XDM Spec 5.1.7.5 |
+| _generate_chc() | [0..*] | method | Generate d:chc with value=selected choice name. Non-combined: first choice only; CombinedStrategy: all choices. Type defaults via namespace-aware heuristic | XDM Spec 5.1.7.2, 5.2.6 |
+| _generate_children() | [0..*] | method | Dispatch per node type; auto-wrap MULTI-CONFIGURATION-CONTAINER and non-1 multiplicity in d:lst | XDM Spec 5.2.5 |
+| _emit_a_attr() | [0..*] | helper | Emit `<a:a name=... value=.../>` child element | XDM Spec 5.2.1.14 |
+| _emit_da_attr() | [0..*] | helper | Emit `<a:da name=... value=.../>` child element | XDM Spec 5.2.1.6.1 |
 
 **Output Wrapper Structure:**
 ```
@@ -115,7 +118,41 @@ datamodel → d:ctr(AUTOSAR) → d:lst(TOP-LEVEL-PACKAGES) → d:ctr(AR-PACKAGE)
 
 **Implementation:** `generator/data_generator.py`
 **Status:** Implemented
-**Last Validated:** 2026-06-07
+**Last Validated:** 2026-06-15
+
+---
+
+### SWR_GEN_00007 - Multiplicity Auto-Wrap Rules
+
+Apply XDM Spec 5.2.5 multiplicity wrapping rules during data-node generation.
+
+| Field | Multiplicity | Type | Description | Origin |
+| --- | --- | --- | --- | --- |
+| MULTI-CONFIG-CONTAINER wrap | [1] | rule | Standalone `v:ctr type="MULTIPLE-CONFIGURATION-CONTAINER"` emitted as `d:lst > d:ctr` | XDM Spec 5.2.5 |
+| Multiplicity auto-wrap | [1] | rule | Any non-lst element with `LOWER-MULTIPLICITY != 1` or `UPPER-MULTIPLICITY != 1` auto-wrapped in `d:lst` with element SHORT-NAME | XDM Spec 5.2.5 |
+| NAME_PATTERN substitution | [1] | rule | Entry naming: NAME_PATTERN with `?` replaced by index, else `<childName>_<index>` | XDM Spec 5.2.5 |
+
+**Implementation:** `generator/data_generator.py:_generate_children/_generate_wrapped`
+**Status:** Implemented
+**Last Validated:** 2026-06-15
+
+---
+
+### SWR_GEN_00008 - Optional Elements Handling
+
+Apply XDM Spec 5.2.5.1 optional-element semantics across new and old schema representations.
+
+| Field | Multiplicity | Type | Description | Origin |
+| --- | --- | --- | --- | --- |
+| OPTIONAL attribute parse | [1] | rule | Parse `<a:a name="OPTIONAL" value="true"/>` on v:var/v:ctr/v:ref | XDM Spec 5.2.5.1 |
+| Old-style optional detection | [1] | rule | Detect `v:lst` with `MIN=0`, `MAX=1` as optional singleton | XDM Spec 5.2.5.1 |
+| ENABLE=true scoping | [1] | rule | CombinedStrategy emits `<a:a name="ENABLE" value="true"/>` only on optional elements (not unconditional) | XDM Spec 5.2.5.1 |
+| Combined variant optional emission | [1] | rule | Optional singleton under CombinedStrategy: 1 entry + ENABLE=true | XDM Spec 5.2.5.1 |
+| Non-combined optional emission | [1] | rule | Optional singleton under non-combined variants: omitted (stays inactive) | XDM Spec 5.2.5.1 |
+
+**Implementation:** `generator/schema_parser.py:_parse_var/_parse_ctr/_parse_ref`, `generator/data_generator.py:_generate_lst`
+**Status:** Implemented
+**Last Validated:** 2026-06-15
 
 ---
 
@@ -134,7 +171,7 @@ Command-line interface for the XDM model generator tool.
 **Entry Point:** `model-xdm-generator` in `pyproject.toml`
 **Implementation:** `generator/cli.py`
 **Status:** Implemented
-**Last Validated:** 2026-06-07
+**Last Validated:** 2026-06-15
 
 ---
 
@@ -151,4 +188,4 @@ Generated model XDM files must be detectable by the existing `eb-convert` tool. 
 
 **Implementation:** `tests/generator/test_eb_convert_verification.py`
 **Status:** Implemented
-**Last Validated:** 2026-06-07
+**Last Validated:** 2026-06-15

--- a/docs/usage/model-xdm-generator.md
+++ b/docs/usage/model-xdm-generator.md
@@ -83,7 +83,7 @@ model-xdm-generator Os.xdm -o Os_random.xdm --variant random --seed 42
 
 #### 4. Combined Variant (default)
 
-Cycles through defaults, boundary, and random strategies per element using `idx % 3`: index 0 uses defaults, 1 uses boundary, 2 uses random, then repeats. Enables all optional elements.
+Cycles through defaults, boundary, and random strategies per element using `idx % 3`: index 0 uses defaults, 1 uses boundary, 2 uses random, then repeats. Activates optional elements.
 
 ```bash
 model-xdm-generator Os.xdm -o Os_combined.xdm --variant combined
@@ -91,7 +91,7 @@ model-xdm-generator Os.xdm -o Os_combined.xdm --variant combined
 
 **Characteristics:**
 - Comprehensive coverage in single file
-- Activates optional elements (adds `ENABLE=true`)
+- Activates optional elements (adds `ENABLE=true` only to elements marked optional via `<a:a name="OPTIONAL" value="true"/>` or wrapped in list with `MIN=0 MAX=1` — see [Optional Elements](#optional-elements))
 - Default variant when `--variant` omitted
 
 ## Value Generation Rules
@@ -123,7 +123,8 @@ Example: `ASPath:/AUTOSAR/EcucDefs/Os/OsCounter`
 ### List Handling
 
 Lists are populated with multiple entries. Without `--list-entries`, the generator uses schema multiplicity:
-- `MIN == 0` → 2 entries (basic coverage)
+- Optional singleton (`MIN=0`, `MAX=1`): handled per [Optional Elements](#optional-elements) below
+- `MIN == 0` (non-singleton) → 2 entries (basic coverage)
 - `MIN > 0` → `max(MIN + 2, 3)` entries (capped at MAX if set)
 
 ```bash
@@ -134,6 +135,32 @@ model-xdm-generator Os.xdm -o Os_3tasks.xdm --list-entries 3
 List entry naming follows schema convention:
 - If schema defines `NAME_PATTERN`: pattern with `?` replaced by index
 - Otherwise: `<childName>_<index>` (e.g., `OsTask_0`, `OsTask_1`)
+
+### Container Type Mapping
+
+The generator applies schema-to-data node type rules from [XDM Mapping Rules](xdm-mapping-rules.md):
+
+- **`v:ctr type="MULTIPLE-CONFIGURATION-CONTAINER"`**: standalone occurrences are auto-wrapped in `d:lst` (per XDM Spec 5.2.5). When schema already wraps the container in `v:lst`, generator honors the existing wrap.
+- **`v:ctr type="INSTANCE"`**: preserves `TARGET` and `CONTEXT` data attributes, emitting them as `a:da` children on the `d:ctr`.
+- **`v:var` with `<a:a name="DERIVED" value="true"/>`**: emits matching `<a:a name="DERIVED" value="true"/>` on the `d:var`.
+- **Multiplicity auto-wrap** (XDM Spec 5.2.5): any `v:var`, `v:ctr`, or `v:ref` carrying `LOWER-MULTIPLICITY != 1` or `UPPER-MULTIPLICITY != 1` (without being inside a `v:lst`) is auto-wrapped in `d:lst` with the element's SHORT-NAME.
+- **Choice type default**: when a `v:chc` element lacks a `type` attribute, generator infers from schema namespace — `DataModel2/08` namespaces default to `type="CHOICE"` (AUTOSAR 2.x style); all others default to `type="IDENTIFIABLE"` (AUTOSAR 3.x+).
+
+### Optional Elements
+
+Optional elements follow XDM Spec 5.2.5.1. Two schema representations are recognized:
+
+- **New style**: `<a:a name="OPTIONAL" value="true"/>` plus `<a:da name="ENABLE" value="false"/>` on the element directly.
+- **Old style**: element wrapped in `<v:lst>` with `<a:da name="MIN" value="0"/>` and `<a:da name="MAX" value="1"/>`.
+
+Generator behavior by variant:
+
+| Variant | Optional element output |
+|---------|-------------------------|
+| `combined` | 1 entry with `<a:a name="ENABLE" value="true"/>` (element activated) |
+| Other variants | Element omitted (stays inactive) |
+
+For non-optional elements, no `ENABLE` attribute is emitted.
 
 ## Advanced Usage
 

--- a/src/eb_model/generator/data_generator.py
+++ b/src/eb_model/generator/data_generator.py
@@ -20,6 +20,18 @@ _XDM_NS = {
     'd': 'http://www.tresos.de/_projects/DataModel2/06/data.xsd',
 }
 
+# Schema/data attribute names and special values (avoid typo-driven divergence)
+_ATTR_ENABLE = 'ENABLE'
+_ATTR_DERIVED = 'DERIVED'
+_ATTR_TARGET = 'TARGET'
+_ATTR_CONTEXT = 'CONTEXT'
+_VALUE_TRUE = 'true'
+_CTR_MULTI_CONFIG = 'MULTIPLE-CONFIGURATION-CONTAINER'
+_CTR_INSTANCE = 'INSTANCE'
+_CHC_CHOICE = 'CHOICE'
+_CHC_IDENTIFIABLE = 'IDENTIFIABLE'
+_NS_LEGACY_VERSION = 'DataModel2/08/'
+
 
 class DataGenerator:
     """Generate d: element tree from schema model."""
@@ -86,16 +98,49 @@ class DataGenerator:
     def _generate_children(self, children, parent_elem, d_prefix: str) -> None:
         """Generate d: elements for schema children."""
         for child in children:
+            # Multiplicity auto-wrap rule (XDM Spec 5.2.5): any element with
+            # LOWER-MULTIPLICITY != 1 or UPPER-MULTIPLICITY != 1 is wrapped in d:lst.
+            if not isinstance(child, SchemaLst) and self._needs_multiplicity_wrap(child):
+                self._generate_wrapped(child, parent_elem, d_prefix)
+                continue
             if isinstance(child, SchemaVar):
                 self._generate_var(child, parent_elem, d_prefix)
             elif isinstance(child, SchemaCtr):
-                self._generate_ctr(child, parent_elem, d_prefix)
+                # Standalone MULTI-CONFIG-CONTAINER is always wrapped in d:lst (XDM Spec 5.2.5)
+                if child.ctr_type == _CTR_MULTI_CONFIG:
+                    wrap_lst = ET.SubElement(parent_elem, '%slst' % d_prefix)
+                    wrap_lst.set('name', child.name)
+                    self._generate_ctr(child, wrap_lst, d_prefix)
+                else:
+                    self._generate_ctr(child, parent_elem, d_prefix)
             elif isinstance(child, SchemaLst):
                 self._generate_lst(child, parent_elem, d_prefix)
             elif isinstance(child, SchemaRef):
                 self._generate_ref(child, parent_elem, d_prefix)
             elif isinstance(child, SchemaChc):
                 self._generate_chc(child, parent_elem, d_prefix)
+
+    @staticmethod
+    def _needs_multiplicity_wrap(child) -> bool:
+        """Check if a non-lst child has multiplicity requiring d:lst wrap."""
+        lower = getattr(child, 'lower_multiplicity', None)
+        upper = getattr(child, 'upper_multiplicity', None)
+        if lower is not None and lower != 1:
+            return True
+        if upper is not None and upper != 1:
+            return True
+        return False
+
+    def _generate_wrapped(self, child, parent_elem, d_prefix: str) -> None:
+        """Wrap a non-lst child in synthetic SchemaLst and emit via _generate_lst."""
+        synth_lst = SchemaLst(
+            name=child.name,
+            lst_type="MAP",
+            min_entries=getattr(child, 'lower_multiplicity', None) or 0,
+            max_entries=getattr(child, 'upper_multiplicity', None),
+            child=child,
+        )
+        self._generate_lst(synth_lst, parent_elem, d_prefix)
 
     def _generate_var(self, var: SchemaVar, parent: ET.Element, d_prefix: str) -> None:
         """Generate a d:var element."""
@@ -106,28 +151,37 @@ class DataGenerator:
         if value:
             elem.set('value', value)
 
-        # For combined variant, add ENABLE attribute to ensure optional items are active
-        if isinstance(self.strategy, CombinedStrategy):
-            a_ns = self._ns_for_output.get('a', '')
-            a_prefix = '{%s}' % a_ns if a_ns else ''
-            enable = ET.SubElement(elem, '%sa' % a_prefix)
-            enable.set('name', 'ENABLE')
-            enable.set('value', 'true')
+        if var.derived:
+            self._emit_attr(elem, 'a', _ATTR_DERIVED, var.derived)
+
+        # Combined variant activates optional elements via ENABLE=true (XDM Spec 5.2.5.1)
+        if isinstance(self.strategy, CombinedStrategy) and var.optional == _VALUE_TRUE:
+            self._emit_attr(elem, 'a', _ATTR_ENABLE, _VALUE_TRUE)
+
+    def _emit_attr(self, parent: ET.Element, tag: str, name: str, value: str) -> None:
+        """Emit <a:{tag} name=... value=.../> as child of parent. tag is 'a' or 'da'."""
+        a_ns = self._ns_for_output.get('a', '')
+        a_prefix = '{%s}' % a_ns if a_ns else ''
+        attr = ET.SubElement(parent, '%s%s' % (a_prefix, tag))
+        attr.set('name', name)
+        attr.set('value', value)
 
     def _generate_ctr(self, ctr: SchemaCtr, parent: ET.Element, d_prefix: str) -> None:
         """Generate a d:ctr element."""
         elem = ET.SubElement(parent, '%sctr' % d_prefix)
         elem.set('name', ctr.name)
         elem.set('type', ctr.ctr_type)
+        # INSTANCE containers carry TARGET/CONTEXT data attributes (XDM Spec 5.2.1.6.1)
+        if ctr.ctr_type == _CTR_INSTANCE:
+            if ctr.target:
+                self._emit_attr(elem, 'da', _ATTR_TARGET, ctr.target)
+            if ctr.context:
+                self._emit_attr(elem, 'da', _ATTR_CONTEXT, ctr.context)
         self._generate_children(ctr.children, elem, d_prefix)
 
-        # For combined variant, add ENABLE attribute to ensure optional items are active
-        if isinstance(self.strategy, CombinedStrategy):
-            a_ns = self._ns_for_output.get('a', '')
-            a_prefix = '{%s}' % a_ns if a_ns else ''
-            enable = ET.SubElement(elem, '%sa' % a_prefix)
-            enable.set('name', 'ENABLE')
-            enable.set('value', 'true')
+        # Combined variant activates optional elements via ENABLE=true (XDM Spec 5.2.5.1)
+        if isinstance(self.strategy, CombinedStrategy) and ctr.optional == _VALUE_TRUE:
+            self._emit_attr(elem, 'a', _ATTR_ENABLE, _VALUE_TRUE)
 
     def _generate_lst(self, lst: SchemaLst, parent: ET.Element, d_prefix: str) -> None:
         """Generate a d:lst element with entries."""
@@ -136,15 +190,23 @@ class DataGenerator:
         if lst.lst_type:
             elem.set('type', lst.lst_type)
 
-        # Determine number of entries
-        # If min_entries == 0: generate 2 entries (basic coverage)
-        # If min_entries > 0: generate min_entries + 2 (verify multiplicity)
-        # Cap at max_entries if set
-        if lst.min_entries == 0:
+        # Optional element old-style representation: list with MIN=0, MAX=1 (XDM Spec 5.2.5.1)
+        is_optional = lst.min_entries == 0 and lst.max_entries == 1
+        entry_optional = None
+        if is_optional:
+            if isinstance(self.strategy, CombinedStrategy):
+                num_entries = 1
+                entry_optional = _VALUE_TRUE
+            else:
+                # Non-combined: optional stays inactive by default
+                num_entries = 0
+        elif lst.min_entries == 0:
+            # Non-optional list with min=0: generate 2 entries (basic coverage)
             num_entries = 2
         else:
+            # min>0: generate min+2 (verify multiplicity), at least 3
             num_entries = max(lst.min_entries + 2, 3)
-        if lst.max_entries is not None:
+        if lst.max_entries is not None and not is_optional:
             num_entries = min(num_entries, lst.max_entries)
 
         # Override if explicit list_entries specified
@@ -161,6 +223,7 @@ class DataGenerator:
                         ctr_type=lst.child.ctr_type,
                         children=list(lst.child.children),
                         name_pattern=lst.child.name_pattern,
+                        optional=entry_optional,
                     )
                     self._generate_ctr(entry, elem, d_prefix)
                 elif isinstance(lst.child, SchemaVar):
@@ -169,6 +232,7 @@ class DataGenerator:
                         var_type=lst.child.var_type,
                         default=lst.child.default,
                         range_info=lst.child.range_info,
+                        optional=entry_optional,
                     )
                     self._generate_var(entry, elem, d_prefix)
                 elif isinstance(lst.child, SchemaRef):
@@ -176,6 +240,7 @@ class DataGenerator:
                         name=name,
                         ref_type=lst.child.ref_type,
                         ref_targets=list(lst.child.ref_targets),
+                        optional=entry_optional,
                     )
                     self._generate_ref(entry, elem, d_prefix)
 
@@ -188,34 +253,44 @@ class DataGenerator:
         if value:
             elem.set('value', value)
 
-        # For combined variant, add ENABLE attribute to ensure optional items are active
-        if isinstance(self.strategy, CombinedStrategy):
-            a_ns = self._ns_for_output.get('a', '')
-            a_prefix = '{%s}' % a_ns if a_ns else ''
-            enable = ET.SubElement(elem, '%sa' % a_prefix)
-            enable.set('name', 'ENABLE')
-            enable.set('value', 'true')
+        # Combined variant activates optional elements via ENABLE=true (XDM Spec 5.2.5.1)
+        if isinstance(self.strategy, CombinedStrategy) and ref.optional == _VALUE_TRUE:
+            self._emit_attr(elem, 'a', _ATTR_ENABLE, _VALUE_TRUE)
 
     def _generate_chc(self, chc: SchemaChc, parent: ET.Element, d_prefix: str) -> None:
         """Generate a d:chc element using first choice (or all for combined variant)."""
+        # Determine chc type, falling back to AUTOSAR-version-aware default if missing
+        chc_type = chc.chc_type or self._chc_default_type()
+
         # For combined variant, generate all choice options
         if isinstance(self.strategy, CombinedStrategy) and chc.choices:
             for choice in chc.choices:
                 elem = ET.SubElement(parent, '%schc' % d_prefix)
                 elem.set('name', chc.name)
-                elem.set('type', chc.chc_type)
+                elem.set('type', chc_type)
                 elem.set('value', choice.name)
                 self._generate_ctr(choice, elem, d_prefix)
         else:
             # Other variants: generate first choice only
             elem = ET.SubElement(parent, '%schc' % d_prefix)
             elem.set('name', chc.name)
-            elem.set('type', chc.chc_type)
+            elem.set('type', chc_type)
 
             if chc.choices:
                 first = chc.choices[0]
                 elem.set('value', first.name)
                 self._generate_ctr(first, elem, d_prefix)
+
+    def _chc_default_type(self) -> str:
+        """Return default chc type based on schema namespace version (XDM Spec 5.2.6).
+
+        DataModel2/08 namespaces → AUTOSAR 2.x style → 'CHOICE'.
+        DataModel2/16 (or unknown) → AUTOSAR 3.x+ → 'IDENTIFIABLE'.
+        """
+        for uri in self._ns_for_output.values():
+            if _NS_LEGACY_VERSION in uri:
+                return _CHC_CHOICE
+        return _CHC_IDENTIFIABLE
 
     def toString(self, tree: ET.ElementTree) -> str:
         """Serialize element tree to XML string with proper namespace declarations."""

--- a/src/eb_model/generator/schema_model.py
+++ b/src/eb_model/generator/schema_model.py
@@ -26,6 +26,10 @@ class SchemaVar:
     label: Optional[str] = None
     desc: Optional[str] = None
     enabled: Optional[str] = None  # ENABLE data attribute value
+    derived: Optional[str] = None  # DERIVED attribute value (XDM Spec 5.2.1.14.3)
+    optional: Optional[str] = None  # OPTIONAL attribute value (XDM Spec 5.2.5.1)
+    lower_multiplicity: Optional[int] = None  # LOWER-MULTIPLICITY (XDM Spec 5.2.5)
+    upper_multiplicity: Optional[int] = None  # UPPER-MULTIPLICITY (XDM Spec 5.2.5)
 
 
 @dataclass
@@ -36,6 +40,9 @@ class SchemaRef:
     ref_targets: List[str] = field(default_factory=list)
     range_targets: List[str] = field(default_factory=list)
     enabled: Optional[str] = None  # ENABLE data attribute value
+    optional: Optional[str] = None  # OPTIONAL attribute value (XDM Spec 5.2.5.1)
+    lower_multiplicity: Optional[int] = None  # LOWER-MULTIPLICITY (XDM Spec 5.2.5)
+    upper_multiplicity: Optional[int] = None  # UPPER-MULTIPLICITY (XDM Spec 5.2.5)
 
 
 @dataclass
@@ -47,6 +54,11 @@ class SchemaCtr:
     name_pattern: Optional[str] = None
     label: Optional[str] = None
     enabled: Optional[str] = None  # ENABLE data attribute value
+    optional: Optional[str] = None  # OPTIONAL attribute value (XDM Spec 5.2.5.1)
+    lower_multiplicity: Optional[int] = None  # LOWER-MULTIPLICITY (XDM Spec 5.2.5)
+    upper_multiplicity: Optional[int] = None  # UPPER-MULTIPLICITY (XDM Spec 5.2.5)
+    target: Optional[str] = None  # INSTANCE TARGET (XDM Spec 5.2.1.6.1)
+    context: Optional[str] = None  # INSTANCE CONTEXT (XDM Spec 5.2.1.6.1)
 
 
 @dataclass

--- a/src/eb_model/generator/schema_parser.py
+++ b/src/eb_model/generator/schema_parser.py
@@ -17,6 +17,9 @@ from .schema_model import (
 
 logger = logging.getLogger(__name__)
 
+# Schema ctr_type values that carry special semantics
+_INSTANCE = "INSTANCE"
+
 
 class SchemaParser:
     """Parse XDM schema files into schema model objects."""
@@ -127,6 +130,10 @@ class SchemaParser:
         ctr_type = element.get('type', 'IDENTIFIABLE')
         name_pattern = self._get_attribute_value(element, 'NAME_PATTERN')
         enabled = self._get_da_value(element, 'ENABLE')
+        optional, lower_mult, upper_mult = self._parse_multiplicity(element)
+        # INSTANCE containers carry TARGET/CONTEXT (XDM Spec 5.2.1.6.1)
+        target = self._get_da_value(element, 'TARGET') if ctr_type == _INSTANCE else None
+        context = self._get_da_value(element, 'CONTEXT') if ctr_type == _INSTANCE else None
 
         children = []
         for child in element:
@@ -148,6 +155,11 @@ class SchemaParser:
             children=children,
             name_pattern=name_pattern,
             enabled=enabled,
+            optional=optional,
+            lower_multiplicity=lower_mult,
+            upper_multiplicity=upper_mult,
+            target=target,
+            context=context,
         )
 
     def _parse_var(self, element: ET.Element) -> SchemaVar:
@@ -157,6 +169,8 @@ class SchemaParser:
         default = self._get_da_value(element, 'DEFAULT')
         label = self._get_attribute_value(element, 'LABEL')
         enabled = self._get_da_value(element, 'ENABLE')
+        derived = self._get_attribute_value(element, 'DERIVED')
+        optional, lower_mult, upper_mult = self._parse_multiplicity(element)
         range_info = self._parse_range(element)
 
         return SchemaVar(
@@ -166,6 +180,10 @@ class SchemaParser:
             range_info=range_info,
             label=label,
             enabled=enabled,
+            derived=derived,
+            optional=optional,
+            lower_multiplicity=lower_mult,
+            upper_multiplicity=upper_mult,
         )
 
     def _parse_lst(self, element: ET.Element) -> SchemaLst:
@@ -174,15 +192,8 @@ class SchemaParser:
         lst_type = element.get('type', '')
         name_pattern = self._get_attribute_value(element, 'NAME_PATTERN')
 
-        min_entries = 0
-        min_val = self._get_da_value(element, 'MIN')
-        if min_val is not None:
-            min_entries = int(min_val)
-
-        max_entries = None
-        max_val = self._get_da_value(element, 'MAX')
-        if max_val is not None:
-            max_entries = int(max_val)
+        min_entries = self._parse_int_da(element, 'MIN') or 0
+        max_entries = self._parse_int_da(element, 'MAX')
 
         # Parse child schema (first v: node child)
         child = None
@@ -212,6 +223,7 @@ class SchemaParser:
         name = element.get('name', '')
         ref_type = element.get('type', 'REFERENCE')
         enabled = self._get_da_value(element, 'ENABLE')
+        optional, lower_mult, upper_mult = self._parse_multiplicity(element)
 
         ref_targets = []
         range_targets = []
@@ -230,7 +242,27 @@ class SchemaParser:
             ref_targets=ref_targets,
             range_targets=range_targets,
             enabled=enabled,
+            optional=optional,
+            lower_multiplicity=lower_mult,
+            upper_multiplicity=upper_mult,
         )
+
+    def _parse_multiplicity(self, element: ET.Element):
+        """Extract OPTIONAL and LOWER/UPPER-MULTIPLICITY (XDM Spec 5.2.5, 5.2.5.1)."""
+        optional = self._get_attribute_value(element, 'OPTIONAL')
+        lower_mult = self._parse_int_da(element, 'LOWER-MULTIPLICITY')
+        upper_mult = self._parse_int_da(element, 'UPPER-MULTIPLICITY')
+        return optional, lower_mult, upper_mult
+
+    def _parse_int_da(self, element: ET.Element, attr_name: str) -> Optional[int]:
+        """Parse an a:da value as int, returning None if absent or non-numeric."""
+        raw = self._get_da_value(element, attr_name)
+        if raw is None:
+            return None
+        try:
+            return int(raw)
+        except (TypeError, ValueError):
+            return None
 
     def _parse_chc(self, element: ET.Element) -> SchemaChc:
         """Parse a v:chc element into SchemaChc."""

--- a/tests/generator/test_data_generator.py
+++ b/tests/generator/test_data_generator.py
@@ -105,6 +105,127 @@ class TestDataGeneratorBasic:
         parsed = ET.fromstring(xml_str)
         assert parsed is not None
 
+    def test_multiple_configuration_container_wrapped_in_lst(self):
+        """Standalone v:ctr type=MULTIPLE-CONFIGURATION-CONTAINER emitted as d:lst > d:ctr."""
+        root = self._make_root([
+            SchemaCtr(name="MultiCfg", ctr_type="MULTIPLE-CONFIGURATION-CONTAINER", children=[
+                SchemaVar(name="Val", var_type="BOOLEAN", default="true"),
+            ]),
+        ])
+        gen = DataGenerator(DefaultsStrategy())
+        xml_str = gen.toString(gen.generate(root))
+        parsed = ET.fromstring(xml_str)
+        # Find the d:ctr type=MULTIPLE-CONFIGURATION-CONTAINER
+        ns = {'d': 'http://www.tresos.de/_projects/DataModel2/06/data.xsd'}
+        ctrs = parsed.findall('.//d:ctr[@type="MULTIPLE-CONFIGURATION-CONTAINER"]', ns)
+        assert len(ctrs) == 1, "MULTIPLE-CONFIGURATION-CONTAINER ctr must be emitted"
+        # Its parent must be a d:lst (the auto-wrap), not the MODULE-CONFIGURATION ctr
+        parent = self._find_parent(parsed, ctrs[0])
+        assert parent is not None
+        assert parent.tag.endswith('}lst'), \
+            "MULTIPLE-CONFIGURATION-CONTAINER ctr must be wrapped in d:lst, got parent: %s" % parent.tag
+
+    @staticmethod
+    def _find_parent(root, target):
+        """Walk tree to find parent of target element."""
+        for elem in root.iter():
+            for child in elem:
+                if child is target:
+                    return elem
+        return None
+
+    def test_var_with_derived_emits_derived_attribute(self):
+        """v:var with DERIVED=true produces d:var with a:a DERIVED=true child."""
+        root = self._make_root([
+            SchemaVar(name="Computed", var_type="INTEGER", derived="true"),
+        ])
+        gen = DataGenerator(DefaultsStrategy())
+        xml_str = gen.toString(gen.generate(root))
+        assert 'name="DERIVED"' in xml_str
+        assert 'value="true"' in xml_str
+
+    def test_var_without_derived_omits_derived_attribute(self):
+        """v:var without derived does not emit DERIVED attribute."""
+        root = self._make_root([
+            SchemaVar(name="Plain", var_type="INTEGER", default="5"),
+        ])
+        gen = DataGenerator(DefaultsStrategy())
+        xml_str = gen.toString(gen.generate(root))
+        assert 'name="DERIVED"' not in xml_str
+
+    def test_var_with_non_one_multiplicity_wrapped_in_lst(self):
+        """v:var with LOWER-MULTIPLICITY != 1 emitted wrapped in d:lst (XDM Spec 5.2.5)."""
+        root = self._make_root([
+            SchemaVar(name="Multi", var_type="INTEGER", default="0",
+                      lower_multiplicity=2, upper_multiplicity=5),
+        ])
+        gen = DataGenerator(DefaultsStrategy())
+        xml_str = gen.toString(gen.generate(root))
+        parsed = ET.fromstring(xml_str)
+        ns = {'d': 'http://www.tresos.de/_projects/DataModel2/06/data.xsd'}
+        lst = parsed.find('.//d:lst[@name="Multi"]', ns)
+        assert lst is not None, "var with non-1 multiplicity must be wrapped in d:lst"
+        # Verify multiplicity was honored: at least min (2) entries
+        vars_in_lst = lst.findall('d:var', ns)
+        assert len(vars_in_lst) >= 2
+
+    def test_var_with_unit_multiplicity_not_wrapped(self):
+        """v:var with no multiplicity (default 1) is NOT wrapped in d:lst."""
+        root = self._make_root([
+            SchemaVar(name="Single", var_type="INTEGER", default="0"),
+        ])
+        gen = DataGenerator(DefaultsStrategy())
+        xml_str = gen.toString(gen.generate(root))
+        assert '<d:lst name="Single"' not in xml_str
+
+    def test_instance_ctr_emits_target_context(self):
+        """v:ctr type=INSTANCE with target/context emits a:da TARGET/CONTEXT."""
+        root = self._make_root([
+            SchemaCtr(name="OsTask", ctr_type="INSTANCE",
+                      target="ASPathDataOfSchema:/TestMod/OsTask",
+                      context="ASPath:/TestMod/OsConfig"),
+        ])
+        gen = DataGenerator(DefaultsStrategy())
+        xml_str = gen.toString(gen.generate(root))
+        assert 'name="TARGET"' in xml_str
+        assert 'ASPathDataOfSchema:/TestMod/OsTask' in xml_str
+        assert 'name="CONTEXT"' in xml_str
+        assert 'ASPath:/TestMod/OsConfig' in xml_str
+
+    def test_chc_empty_type_defaults_to_identifiable_for_modern_schema(self):
+        """v:chc with empty type under DataModel2/16 defaults to IDENTIFIABLE (AUTOSAR 3.x+)."""
+        root = self._make_root([
+            SchemaChc(name="Action", chc_type="", choices=[
+                SchemaCtr(name="OptionA", ctr_type="IDENTIFIABLE"),
+            ]),
+        ])
+        gen = DataGenerator(DefaultsStrategy())
+        xml_str = gen.toString(gen.generate(root))
+        assert 'type="IDENTIFIABLE"' in xml_str
+
+    def test_chc_empty_type_defaults_to_choice_for_legacy_schema(self):
+        """v:chc with empty type under DataModel2/08 defaults to CHOICE (AUTOSAR 2.x)."""
+        module_def = SchemaCtr(name="TestMod", ctr_type="MODULE-DEF", children=[
+            SchemaChc(name="Action", chc_type="", choices=[
+                SchemaCtr(name="OptionA", ctr_type="IDENTIFIABLE"),
+            ]),
+        ])
+        root = SchemaRoot(
+            module_name="TestMod",
+            module_def=module_def,
+            version="7.0",
+            namespaces={
+                '': 'http://www.tresos.de/_projects/DataModel2/08/root.xsd',
+                'a': 'http://www.tresos.de/_projects/DataModel2/08/attribute.xsd',
+                'v': 'http://www.tresos.de/_projects/DataModel2/08/schema.xsd',
+                'd': 'http://www.tresos.de/_projects/DataModel2/08/data.xsd',
+            },
+            ar_package_name="TestPkg",
+        )
+        gen = DataGenerator(DefaultsStrategy())
+        xml_str = gen.toString(gen.generate(root))
+        assert 'type="CHOICE"' in xml_str
+
 
 class TestDataGeneratorCombined:
     """Tests for combined variant data generation."""
@@ -149,6 +270,31 @@ class TestDataGeneratorCombined:
         xml_str = gen.toString(gen.generate(root))
         assert xml_str.count('name="Item_') == 3
 
+    def test_optional_list_min_zero_max_one_combined_emits_single_entry_with_enable(self):
+        """Optional list (MIN=0, MAX=1) under Combined: 1 entry with ENABLE=true (XDM Spec 5.2.5.1)."""
+        root = self._make_root([
+            SchemaLst(name="OptItem", lst_type="MAP", min_entries=0, max_entries=1,
+                      child=SchemaCtr(name="Item", ctr_type="IDENTIFIABLE", children=[
+                          SchemaVar(name="Val", var_type="INTEGER", default="0"),
+                      ])),
+        ])
+        gen = DataGenerator(CombinedStrategy(seed=42))
+        xml_str = gen.toString(gen.generate(root))
+        assert xml_str.count('name="Item_') == 1
+        assert 'name="ENABLE"' in xml_str
+
+    def test_optional_list_min_zero_max_one_defaults_emits_zero_entries(self):
+        """Optional list (MIN=0, MAX=1) under Defaults: 0 entries (stays inactive)."""
+        root = self._make_root([
+            SchemaLst(name="OptItem", lst_type="MAP", min_entries=0, max_entries=1,
+                      child=SchemaCtr(name="Item", ctr_type="IDENTIFIABLE", children=[
+                          SchemaVar(name="Val", var_type="INTEGER", default="0"),
+                      ])),
+        ])
+        gen = DataGenerator(DefaultsStrategy())
+        xml_str = gen.toString(gen.generate(root))
+        assert xml_str.count('name="Item_') == 0
+
     def test_choice_generates_all_options(self):
         """Choice generates all options for combined variant."""
         root = self._make_root([
@@ -169,19 +315,28 @@ class TestDataGeneratorCombined:
         assert 'OptionB' in xml_str
 
     def test_optional_items_have_enable(self):
-        """Combined variant adds ENABLE attribute to optional items."""
+        """Combined variant adds ENABLE=true to optional var items."""
         root = self._make_root([
-            SchemaVar(name="TestBool", var_type="BOOLEAN", default="true", enabled="false"),
+            SchemaVar(name="TestBool", var_type="BOOLEAN", default="true", optional="true"),
         ])
         gen = DataGenerator(CombinedStrategy(seed=42))
         xml_str = gen.toString(gen.generate(root))
         assert 'name="ENABLE"' in xml_str
         assert 'value="true"' in xml_str
 
-    def test_container_has_enable(self):
-        """Combined variant adds ENABLE attribute to containers."""
+    def test_non_optional_var_omits_enable(self):
+        """Combined variant does not add ENABLE to non-optional vars."""
         root = self._make_root([
-            SchemaCtr(name="General", ctr_type="IDENTIFIABLE", children=[
+            SchemaVar(name="Plain", var_type="BOOLEAN", default="true"),
+        ])
+        gen = DataGenerator(CombinedStrategy(seed=42))
+        xml_str = gen.toString(gen.generate(root))
+        assert 'name="ENABLE"' not in xml_str
+
+    def test_container_has_enable(self):
+        """Combined variant adds ENABLE=true to optional containers."""
+        root = self._make_root([
+            SchemaCtr(name="General", ctr_type="IDENTIFIABLE", optional="true", children=[
                 SchemaVar(name="Enabled", var_type="BOOLEAN", default="true"),
             ]),
         ])
@@ -190,13 +345,34 @@ class TestDataGeneratorCombined:
         assert 'name="ENABLE"' in xml_str
         assert 'value="true"' in xml_str
 
-    def test_reference_has_enable(self):
-        """Combined variant adds ENABLE attribute to references."""
+    def test_non_optional_container_omits_enable(self):
+        """Combined variant does not add ENABLE to non-optional containers."""
         root = self._make_root([
-            SchemaRef(name="TargetRef", ref_type="REFERENCE",
+            SchemaCtr(name="General", ctr_type="IDENTIFIABLE", children=[
+                SchemaVar(name="Enabled", var_type="BOOLEAN", default="true"),
+            ]),
+        ])
+        gen = DataGenerator(CombinedStrategy(seed=42))
+        xml_str = gen.toString(gen.generate(root))
+        assert 'name="ENABLE"' not in xml_str
+
+    def test_reference_has_enable(self):
+        """Combined variant adds ENABLE=true to optional references."""
+        root = self._make_root([
+            SchemaRef(name="TargetRef", ref_type="REFERENCE", optional="true",
                       ref_targets=["ASPathDataOfSchema:/TestMod/Cfg/Target"]),
         ])
         gen = DataGenerator(CombinedStrategy(seed=42))
         xml_str = gen.toString(gen.generate(root))
         assert 'name="ENABLE"' in xml_str
         assert 'value="true"' in xml_str
+
+    def test_non_optional_reference_omits_enable(self):
+        """Combined variant does not add ENABLE to non-optional references."""
+        root = self._make_root([
+            SchemaRef(name="TargetRef", ref_type="REFERENCE",
+                      ref_targets=["ASPathDataOfSchema:/TestMod/Cfg/Target"]),
+        ])
+        gen = DataGenerator(CombinedStrategy(seed=42))
+        xml_str = gen.toString(gen.generate(root))
+        assert 'name="ENABLE"' not in xml_str

--- a/tests/generator/test_schema_parser.py
+++ b/tests/generator/test_schema_parser.py
@@ -243,3 +243,122 @@ class TestSchemaParserBasic:
         assert isinstance(chc, SchemaChc)
         assert chc.name == "Action"
         assert len(chc.choices) == 2
+
+    def test_parse_var_with_derived(self):
+        """Parse v:var with DERIVED a:a attribute."""
+        xml = """<datamodel version="7.0"
+            xmlns="http://www.tresos.de/_projects/DataModel2/16/root.xsd"
+            xmlns:a="http://www.tresos.de/_projects/DataModel2/16/attribute.xsd"
+            xmlns:v="http://www.tresos.de/_projects/DataModel2/06/schema.xsd"
+            xmlns:d="http://www.tresos.de/_projects/DataModel2/06/data.xsd">
+          <d:ctr type="AUTOSAR" factory="autosar">
+            <d:lst type="TOP-LEVEL-PACKAGES">
+              <d:ctr name="TestPkg" type="AR-PACKAGE">
+                <d:lst type="ELEMENTS">
+                  <d:chc name="TestMod" type="AR-ELEMENT" value="MODULE-DEF">
+                    <v:ctr type="MODULE-DEF">
+                      <v:var name="Computed" type="INTEGER">
+                        <a:a name="DERIVED" value="true"/>
+                      </v:var>
+                    </v:ctr>
+                  </d:chc>
+                </d:lst>
+              </d:ctr>
+            </d:lst>
+          </d:ctr>
+        </datamodel>"""
+        root = self._parse_xml(xml)
+        var = root.module_def.children[0]
+        assert isinstance(var, SchemaVar)
+        assert var.derived == "true"
+
+    def test_parse_var_with_optional(self):
+        """Parse v:var with OPTIONAL a:a attribute."""
+        xml = """<datamodel version="7.0"
+            xmlns="http://www.tresos.de/_projects/DataModel2/16/root.xsd"
+            xmlns:a="http://www.tresos.de/_projects/DataModel2/16/attribute.xsd"
+            xmlns:v="http://www.tresos.de/_projects/DataModel2/06/schema.xsd"
+            xmlns:d="http://www.tresos.de/_projects/DataModel2/06/data.xsd">
+          <d:ctr type="AUTOSAR" factory="autosar">
+            <d:lst type="TOP-LEVEL-PACKAGES">
+              <d:ctr name="TestPkg" type="AR-PACKAGE">
+                <d:lst type="ELEMENTS">
+                  <d:chc name="TestMod" type="AR-ELEMENT" value="MODULE-DEF">
+                    <v:ctr type="MODULE-DEF">
+                      <v:var name="OptParam" type="BOOLEAN">
+                        <a:a name="OPTIONAL" value="true"/>
+                        <a:da name="ENABLE" value="false"/>
+                      </v:var>
+                    </v:ctr>
+                  </d:chc>
+                </d:lst>
+              </d:ctr>
+            </d:lst>
+          </d:ctr>
+        </datamodel>"""
+        root = self._parse_xml(xml)
+        var = root.module_def.children[0]
+        assert isinstance(var, SchemaVar)
+        assert var.optional == "true"
+        assert var.enabled == "false"
+
+    def test_parse_var_with_multiplicity(self):
+        """Parse v:var with LOWER-MULTIPLICITY/UPPER-MULTIPLICITY."""
+        xml = """<datamodel version="7.0"
+            xmlns="http://www.tresos.de/_projects/DataModel2/16/root.xsd"
+            xmlns:a="http://www.tresos.de/_projects/DataModel2/16/attribute.xsd"
+            xmlns:v="http://www.tresos.de/_projects/DataModel2/06/schema.xsd"
+            xmlns:d="http://www.tresos.de/_projects/DataModel2/06/data.xsd">
+          <d:ctr type="AUTOSAR" factory="autosar">
+            <d:lst type="TOP-LEVEL-PACKAGES">
+              <d:ctr name="TestPkg" type="AR-PACKAGE">
+                <d:lst type="ELEMENTS">
+                  <d:chc name="TestMod" type="AR-ELEMENT" value="MODULE-DEF">
+                    <v:ctr type="MODULE-DEF">
+                      <v:var name="Multi" type="INTEGER">
+                        <a:da name="LOWER-MULTIPLICITY" value="2"/>
+                        <a:da name="UPPER-MULTIPLICITY" value="5"/>
+                      </v:var>
+                    </v:ctr>
+                  </d:chc>
+                </d:lst>
+              </d:ctr>
+            </d:lst>
+          </d:ctr>
+        </datamodel>"""
+        root = self._parse_xml(xml)
+        var = root.module_def.children[0]
+        assert isinstance(var, SchemaVar)
+        assert var.lower_multiplicity == 2
+        assert var.upper_multiplicity == 5
+
+    def test_parse_instance_ctr_with_target_context(self):
+        """Parse v:ctr type=INSTANCE with TARGET and CONTEXT a:da attributes."""
+        xml = """<datamodel version="7.0"
+            xmlns="http://www.tresos.de/_projects/DataModel2/16/root.xsd"
+            xmlns:a="http://www.tresos.de/_projects/DataModel2/16/attribute.xsd"
+            xmlns:v="http://www.tresos.de/_projects/DataModel2/06/schema.xsd"
+            xmlns:d="http://www.tresos.de/_projects/DataModel2/06/data.xsd">
+          <d:ctr type="AUTOSAR" factory="autosar">
+            <d:lst type="TOP-LEVEL-PACKAGES">
+              <d:ctr name="TestPkg" type="AR-PACKAGE">
+                <d:lst type="ELEMENTS">
+                  <d:chc name="TestMod" type="AR-ELEMENT" value="MODULE-DEF">
+                    <v:ctr type="MODULE-DEF">
+                      <v:ctr name="OsTask" type="INSTANCE">
+                        <a:da name="TARGET" value="ASPathDataOfSchema:/TestMod/OsTask"/>
+                        <a:da name="CONTEXT" value="ASPath:/TestMod/OsConfig"/>
+                      </v:ctr>
+                    </v:ctr>
+                  </d:chc>
+                </d:lst>
+              </d:ctr>
+            </d:lst>
+          </d:ctr>
+        </datamodel>"""
+        root = self._parse_xml(xml)
+        ctr = root.module_def.children[0]
+        assert isinstance(ctr, SchemaCtr)
+        assert ctr.ctr_type == "INSTANCE"
+        assert ctr.target == "ASPathDataOfSchema:/TestMod/OsTask"
+        assert ctr.context == "ASPath:/TestMod/OsConfig"


### PR DESCRIPTION
## Summary

- Close 8 gaps between generator implementation and `docs/usage/xdm-mapping-rules.md` (EB Tresos Studio Developer's Guide §5.2)
- Critical: MULTIPLE-CONFIGURATION-CONTAINER auto-wrap + DERIVED attribute propagation
- Moderate: optional element handling (old + new representation), ENABLE=true scoping, multiplicity auto-wrap
- Low: namespace-aware chc default, INSTANCE TARGET/CONTEXT, OPTIONAL attribute parsing
- Refactor: extract `_emit_attr` + `_parse_multiplicity` helpers, module constants for magic strings
- Docs: add SWR_GEN_00007/00008; update `model-xdm-generator.md` with Container Type Mapping + Optional Elements sections

## Test plan

- [x] 14 new TDD unit tests added (`tests/generator/test_schema_parser.py`, `tests/generator/test_data_generator.py`)
- [x] All 650 tests pass (`pytest --no-cov`)
- [x] `ruff check src/eb_model/generator/ tests/generator/` clean
- [x] `flake8 src/eb_model/generator/ tests/generator/ --max-line-length=150 --ignore=F401,W293,F403` clean
- [x] Generator integration tests pass (`Os.xdm`, `CanIf.xdm` round-trip)
- [x] eb-convert module detection verified for Os + CanIf generated XDM

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)